### PR TITLE
Add reflect options for immutability and transparent pointer behavior

### DIFF
--- a/array.go
+++ b/array.go
@@ -21,7 +21,7 @@ func arrayIndex(L *lua.LState) int {
 		if (val.Kind() == reflect.Struct || val.Kind() == reflect.Array) && val.CanAddr() {
 			val = val.Addr()
 		}
-		L.Push(New(L, val.Interface()))
+		L.Push(NewWithOptions(L, val.Interface(), mt.reflectOptions()))
 	case lua.LString:
 		if !isPtr {
 			if fn := mt.method(string(converted)); fn != nil {
@@ -41,10 +41,14 @@ func arrayIndex(L *lua.LState) int {
 }
 
 func arrayNewIndex(L *lua.LState) int {
-	ref, _, isPtr := check(L, 1, reflect.Array)
+	ref, mt, isPtr := check(L, 1, reflect.Array)
 
 	if !isPtr {
 		L.RaiseError("invalid operation on array")
+	}
+
+	if mt.immutable() {
+		L.RaiseError("invalid operation on immutable array")
 	}
 
 	ref = ref.Elem()

--- a/array.go
+++ b/array.go
@@ -21,7 +21,7 @@ func arrayIndex(L *lua.LState) int {
 		if (val.Kind() == reflect.Struct || val.Kind() == reflect.Array) && val.CanAddr() {
 			val = val.Addr()
 		}
-		L.Push(NewWithOptions(L, val.Interface(), mt.reflectOptions()))
+		L.Push(New(L, val.Interface(), mt.reflectOptions()))
 	case lua.LString:
 		if !isPtr {
 			if fn := mt.method(string(converted)); fn != nil {

--- a/cache.go
+++ b/cache.go
@@ -125,7 +125,7 @@ func addFields(L *lua.LState, vtype reflect.Type, tbl *lua.LTable) {
 	}
 }
 
-func getMetatable(L *lua.LState, vtype reflect.Type) *lua.LTable {
+func getMetatable(L *lua.LState, vtype reflect.Type, opts ReflectOptions) *lua.LTable {
 	cache := getMTCache(L)
 
 	if vtype.Kind() == reflect.Ptr {
@@ -182,7 +182,11 @@ func getMetatable(L *lua.LState, vtype reflect.Type) *lua.LTable {
 		mt.RawSetString("__index", L.NewFunction(ptrIndex))
 	}
 
-	addMethods(L, reflect.PtrTo(vtype), ptrMethods, true)
+	// Don't want to allow pointer methods for immutable objects, since they could
+	// mutate state internally
+	if !opts.Immutable {
+		addMethods(L, reflect.PtrTo(vtype), ptrMethods, true)
+	}
 	mt.RawSetString("ptr_methods", ptrMethods)
 
 	addMethods(L, vtype, methods, false)
@@ -190,13 +194,21 @@ func getMetatable(L *lua.LState, vtype reflect.Type) *lua.LTable {
 
 	mt.RawSetString("original", L.NewTable())
 
+	// Reflection options
+	if opts.Immutable {
+		mt.RawSetString("immutable", lua.LTrue)
+	}
+	if opts.TransparentPointers {
+		mt.RawSetString("transparent_pointers", lua.LTrue)
+	}
+
 	cache.regular[vtype] = mt
 	return mt
 }
 
-func getMetatableFromValue(L *lua.LState, value reflect.Value) *lua.LTable {
+func getMetatableFromValue(L *lua.LState, value reflect.Value, opts ReflectOptions) *lua.LTable {
 	vtype := value.Type()
-	return getMetatable(L, vtype)
+	return getMetatable(L, vtype, opts)
 }
 
 func getTypeMetatable(L *lua.LState, t reflect.Type) *lua.LTable {

--- a/chan.go
+++ b/chan.go
@@ -62,7 +62,12 @@ func chanReceive(L *lua.LState) int {
 }
 
 func chanClose(L *lua.LState) int {
-	ref, _, _ := check(L, 1, reflect.Chan)
+	ref, mt, _ := check(L, 1, reflect.Chan)
+
+	if mt.immutable() {
+		L.RaiseError("cannot close immutable channel")
+	}
+
 	ref.Close()
 	return 0
 }

--- a/example_test.go
+++ b/example_test.go
@@ -48,7 +48,7 @@ type outputLogger struct {
 	Lines []string
 }
 
-func (l *outputLogger) Log(lines... interface{}) {
+func (l *outputLogger) Log(lines ...interface{}) {
 	if len(lines) == 0 {
 		l.Lines = append(l.Lines, "")
 		return
@@ -65,7 +65,7 @@ func (l *outputLogger) Equals(other []string) bool {
 	if len(l.Lines) != len(other) {
 		return false
 	}
-	for i, line := range(l.Lines) {
+	for i, line := range l.Lines {
 		if line != other[i] {
 			return false
 		}
@@ -115,7 +115,7 @@ func TestStructUsage(t *testing.T) {
 	if err := L.DoString(code); err != nil {
 		t.Fatal(err)
 	}
-	
+
 	expected := []string{
 		"Tim",
 		"30",
@@ -174,7 +174,7 @@ func TestMapAndSlice(t *testing.T) {
 	logger.Log(thangs["GHI"])
 	_, ok := thangs["ABC"]
 	logger.Log(ok)
-	
+
 	expected := []string{
 		"cake",
 		"wallet",
@@ -226,7 +226,7 @@ func TestStructConstructorAndMap(t *testing.T) {
 
 	everyone := L.GetGlobal("everyone").(*lua.LUserData).Value.(map[string]*Person)
 	logger.Log(len(everyone))
-	
+
 	expected := []string{
 		"John",
 		"Tim",
@@ -260,7 +260,7 @@ func TestGoFunc(t *testing.T) {
 	if err := L.DoString(code); err != nil {
 		t.Fatal(err)
 	}
-	
+
 	expected := []string{
 		"Hello, Tim",
 	}
@@ -293,7 +293,7 @@ func TestChan(t *testing.T) {
 	if err := L.DoString(code); err != nil {
 		t.Fatal(err)
 	}
-	
+
 	expected := []string{
 		"Tim	true",
 		"John	true",
@@ -331,7 +331,7 @@ func TestMap(t *testing.T) {
 	if err := L.DoString(code); err != nil {
 		t.Fatal(err)
 	}
-	
+
 	expected := []string{
 		"Canada",
 		"France",
@@ -365,7 +365,7 @@ func TestFuncVariadic(t *testing.T) {
 	if err := L.DoString(code); err != nil {
 		t.Fatal(err)
 	}
-	
+
 	expected := []string{
 		"a",
 		"1",
@@ -410,7 +410,7 @@ func TestLuaFuncVariadic(t *testing.T) {
 	if err := L.DoString(code); err != nil {
 		t.Fatal(err)
 	}
-	
+
 	expected := []string{
 		"3",
 		"2",
@@ -444,7 +444,7 @@ func TestSlice(t *testing.T) {
 	if err := L.DoString(code); err != nil {
 		t.Fatal(err)
 	}
-	
+
 	expected := []string{
 		"0",
 		"10",
@@ -478,7 +478,7 @@ func TestSliceCapacity(t *testing.T) {
 	if err := L.DoString(code); err != nil {
 		t.Fatal(err)
 	}
-	
+
 	expected := []string{
 		"1	1",
 		"0	10",
@@ -515,7 +515,7 @@ func TestStructPtrEquality(t *testing.T) {
 	if err := L.DoString(code); err != nil {
 		t.Fatal(err)
 	}
-	
+
 	expected := []string{
 		"true",
 		"true",
@@ -553,7 +553,7 @@ func TestStructStringer(t *testing.T) {
 	if err := L.DoString(code); err != nil {
 		t.Fatal(err)
 	}
-	
+
 	expected := []string{
 		"Tim (99)",
 		"John (2)",
@@ -581,7 +581,7 @@ func TestPtrMethod(t *testing.T) {
 	if err := L.DoString(code); err != nil {
 		t.Fatal(err)
 	}
-	
+
 	expected := []string{
 		"Tim counts: 15",
 	}
@@ -610,7 +610,7 @@ func TestStruct(t *testing.T) {
 	if err := L.DoString(code); err != nil {
 		t.Fatal(err)
 	}
-	
+
 	expected := []string{
 		"Hello, Tim",
 		"66",
@@ -658,7 +658,7 @@ func TestArray(t *testing.T) {
 	if err := L.DoString(code); err != nil {
 		t.Fatal(err)
 	}
-	
+
 	expected := []string{
 		"2	Hello	World",
 		"2	World	Hello",
@@ -692,7 +692,7 @@ func TestLuaFunc(t *testing.T) {
 	if err := L.DoString(code); err != nil {
 		t.Fatal(err)
 	}
-	
+
 	expected := []string{
 		"tim	tim	tim	tim	tim",
 	}
@@ -717,7 +717,7 @@ func TestPtrIndirection(t *testing.T) {
 	if err := L.DoString(code); err != nil {
 		t.Fatal(err)
 	}
-	
+
 	expected := []string{
 		"hello",
 	}
@@ -746,7 +746,7 @@ func TestPtrEquality(t *testing.T) {
 	if err := L.DoString(code); err != nil {
 		t.Fatal(err)
 	}
-	
+
 	expected := []string{
 		"true",
 		"false",
@@ -775,7 +775,7 @@ func TestPtrAssignment(t *testing.T) {
 	if err := L.DoString(code); err != nil {
 		t.Fatal(err)
 	}
-	
+
 	expected := []string{
 		"hello",
 		"world",
@@ -823,7 +823,7 @@ func TestAnonymousFields(t *testing.T) {
 	if err := L.DoString(code); err != nil {
 		t.Fatal(err)
 	}
-	
+
 	expected := []string{
 		"true",
 		"false",
@@ -851,7 +851,7 @@ func TestEmptyFunc(t *testing.T) {
 	if err := L.DoString(code); err != nil {
 		t.Fatal(err)
 	}
-	
+
 	expected := []string{
 		"true",
 	}
@@ -880,7 +880,7 @@ func TestFuncArray(t *testing.T) {
 	if err := L.DoString(code); err != nil {
 		t.Fatal(err)
 	}
-	
+
 	expected := []string{
 		"1	2	3",
 	}
@@ -907,7 +907,7 @@ func TestComplex(t *testing.T) {
 	}
 	b := L.GetGlobal("b").(*lua.LUserData).Value.(complex128)
 	logger.Log(a == b)
-	
+
 	expected := []string{
 		"true",
 	}
@@ -967,7 +967,7 @@ func TestTypeAlias(t *testing.T) {
 	if err := L.DoString(code); err != nil {
 		t.Fatal(err)
 	}
-	
+
 	expected := []string{
 		"I'm a \"chan string\" alias",
 		"2	3",
@@ -1005,7 +1005,7 @@ func TestStructPtrFunc(t *testing.T) {
 		t.Fatal(err)
 	}
 	logger.Log(a.B.Test())
-	
+
 	expected := []string{
 		"Pointer test",
 		"Pointer test",
@@ -1048,7 +1048,7 @@ func TestHiddenFieldNames(t *testing.T) {
 	if err := L.DoString(code); err != nil {
 		t.Fatal(err)
 	}
-	
+
 	expected := []string{
 		"tim",
 		"bob",
@@ -1086,7 +1086,7 @@ func TestStructPtrAssignment(t *testing.T) {
 	if err := L.DoString(code); err != nil {
 		t.Fatal(err)
 	}
-	
+
 	expected := []string{
 		"tim",
 		"bob",
@@ -1127,7 +1127,7 @@ func TestPtrNonPtrChanMethods(t *testing.T) {
 	if err := L.DoString(code); err != nil {
 		t.Fatal(err)
 	}
-	
+
 	expected := []string{
 		"Test",
 		"Test2",
@@ -1164,7 +1164,7 @@ func TestStructField(t *testing.T) {
 		t.Fatal(err)
 	}
 	logger.Log(a.StructFieldA)
-	
+
 	expected := []string{
 		"hello",
 		"world",
@@ -1230,7 +1230,7 @@ func TestStructBlacklist(t *testing.T) {
 	if err := L.DoString(code); err != nil {
 		t.Fatal(err)
 	}
-	
+
 	expected := []string{
 		"You can call me",
 		"You can call me",
@@ -1262,7 +1262,7 @@ func TestSliceAssignment(t *testing.T) {
 	for _, v := range e.S {
 		logger.Log(v)
 	}
-	
+
 	expected := []string{
 		"a",
 		"b",
@@ -1307,7 +1307,7 @@ func TestSliceTableAssignment(t *testing.T) {
 	logger.Log(e.S["b"])
 	logger.Log(e.S["c"])
 	logger.Log(e.S["d"])
-	
+
 	expected := []string{
 		"3",
 		"123",
@@ -1365,7 +1365,7 @@ func TestFieldNameResolution(t *testing.T) {
 	logger.Log(e.P.Friend.Age)
 	logger.Log(e.P2.Name)
 	logger.Log(e.P2.Age)
-	
+
 	expected := []string{
 		"Bill",
 		"33",
@@ -1414,7 +1414,7 @@ func TestPCall(t *testing.T) {
 	logger.Log(e.A)
 	logger.Log(e.B)
 	logger.Log(e.C)
-	
+
 	expected := []string{
 		"Cat",
 		"675",
@@ -1468,7 +1468,7 @@ func TestLuaFuncDefinition(t *testing.T) {
 	if L.GetTop() != 0 {
 		t.Fatal("expecting GetTop to return 0, got " + strconv.Itoa(L.GetTop()))
 	}
-	
+
 	expected := []string{
 		">A<	1",
 		">B<	2",
@@ -1506,7 +1506,6 @@ func TestLuaFuncPtr(t *testing.T) {
 	L.Push(e.F1)
 	L.Call(0, 0)
 
-	
 	expected := []string{
 		"Hello World",
 	}
@@ -1554,7 +1553,6 @@ func TestSliceAndArrayTypes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	
 	expected := []string{
 		"1	hello",
 		"2	there",
@@ -1614,7 +1612,6 @@ func TestStructArrayAndSlice(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	
 	expected := []string{
 		"Tim counts: 15",
 		"Tim counts: 10",
@@ -1654,7 +1651,7 @@ func TestLStateFunc(t *testing.T) {
 	if err := L.DoString(code); err != nil {
 		t.Fatal(err)
 	}
-	
+
 	expected := []string{
 		"15",
 	}
@@ -1680,7 +1677,7 @@ func TestNewType(t *testing.T) {
 		s.Artist = "Tycho"
 		log(s.Artist .. " - " .. s.Title)
 	`)
-	
+
 	expected := []string{
 		"Tycho - Montana",
 	}
@@ -2107,7 +2104,7 @@ func TestTransparentPtrAccess(t *testing.T) {
 	if err := L.DoString(code); err != nil {
 		t.Fatal(err)
 	}
-	
+
 	expected := []string{
 		"foo",
 	}
@@ -2139,7 +2136,6 @@ func TestTransparentPtrAssignment(t *testing.T) {
 	a := TransparentPtrAccessA{}
 	b := TransparentPtrAccessB{
 		Str: &val,
-
 	}
 	L.SetGlobal("a", New(L, &a, ReflectOptions{TransparentPointers: true}))
 	L.SetGlobal("b", New(L, &b, ReflectOptions{TransparentPointers: true}))
@@ -2147,7 +2143,7 @@ func TestTransparentPtrAssignment(t *testing.T) {
 	if err := L.DoString(code); err != nil {
 		t.Fatal(err)
 	}
-	
+
 	expected := []string{
 		"assigned ptr value",
 		"new value",
@@ -2175,7 +2171,6 @@ func TestTransparentPtrValueAssignment(t *testing.T) {
 	a := TransparentPtrAccessA{}
 	b := TransparentPtrAccessB{
 		Str: &val,
-
 	}
 	L.SetGlobal("a", New(L, &a, ReflectOptions{TransparentPointers: true}))
 	// Non-pointer
@@ -2192,6 +2187,32 @@ func TestTransparentPtrValueAssignment(t *testing.T) {
 
 	if !logger.Equals(expected) {
 		t.Fatalf("Unexpected output. Expected:\n%s\n\nActual:\n%s", expected, logger.Lines)
+	}
+}
+
+func TestTransparentValueAccess(t *testing.T) {
+	// Attempt to access a nil pointer field on a transparent pointer
+	// struct that was reflected by value. Since we can't actually set
+	// values back to a struct that was reflected by value (as
+	// opposed to by reference), an error will result.
+	const code = `
+	print(b.Str)
+	`
+
+	L := lua.NewState()
+	defer L.Close()
+
+	b := TransparentPtrAccessB{}
+
+	// Non-pointer
+	L.SetGlobal("b", New(L, b, ReflectOptions{TransparentPointers: true}))
+
+	err := L.DoString(code)
+	if err == nil {
+		t.Fatal("Expected error, none thrown")
+	}
+	if !strings.Contains(err.Error(), "cannot transparently create pointer field Str") {
+		t.Fatal("Expected invalid operation error, got:", err)
 	}
 }
 
@@ -2212,7 +2233,7 @@ func TestTransparentNestedStructPtrAccess(t *testing.T) {
 	if err := L.DoString(code); err != nil {
 		t.Fatal(err)
 	}
-	
+
 	expected := []string{
 		"",
 	}
@@ -2240,7 +2261,7 @@ func TestTransparentNestedStructPtrAssignment(t *testing.T) {
 	if err := L.DoString(code); err != nil {
 		t.Fatal(err)
 	}
-	
+
 	expected := []string{
 		"hello, world!",
 	}
@@ -2269,7 +2290,6 @@ func TestTransparentPtrEquality(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	
 	expected := []string{
 		"true",
 	}
@@ -2324,7 +2344,6 @@ func TestTransparentStructSliceField(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	
 	expected := []string{
 		"0",
 	}
@@ -2383,7 +2402,6 @@ func TestTransparentNestedStructVar(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	
 	expected := []string{
 		"hello, world!",
 	}
@@ -2415,7 +2433,6 @@ func TestTransparentSliceElementVar(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	
 	expected := []string{
 		"hello, world!",
 	}

--- a/example_test.go
+++ b/example_test.go
@@ -136,11 +136,11 @@ func ExampleMapAndSlice() {
 	// calendar
 	// phone
 	// speaker
-	// 
+	//
 	// 123
 	// 456
 	// nil
-	// 
+	//
 	// cookie
 	// 789
 	// false
@@ -1076,7 +1076,7 @@ func ExampleSliceAssignment() {
 	// Output:
 	// a
 	// b
-	// 
+	//
 	// 3
 	// true
 	// c
@@ -1116,7 +1116,7 @@ func ExampleSliceTableAssignment() {
 	// Output:
 	// 3
 	// 123
-	// 
+	//
 	// hello
 	// false
 }
@@ -1263,7 +1263,7 @@ func ExampleLuaFuncDefinition() {
 	// >A< 1
 	// >B< 2
 	// >C< 3
-	// 
+	//
 	// hello
 }
 
@@ -1960,7 +1960,7 @@ func ExampleTransparentNestedStructPtrAccess() {
 	}
 
 	// Output:
-	// 
+	//
 }
 
 func ExampleTransparentNestedStructPtrAssignment() {

--- a/example_test.go
+++ b/example_test.go
@@ -38,7 +38,13 @@ func (p *Person) IncreaseAge() {
 	p.Age++
 }
 
-func TestExample__1(t *testing.T) {
+type Family struct {
+	Mother   Person
+	Father   Person
+	Children []Person
+}
+
+func TestStructUsage(t *testing.T) {
 	const code = `
 	print(user1.Name)
 	print(user1.Age)
@@ -78,7 +84,7 @@ func TestExample__1(t *testing.T) {
 	// Hello, John
 }
 
-func TestExample__2(t *testing.T) {
+func TestMapAndSlice(t *testing.T) {
 	const code = `
 	for i = 1, #things do
 		print(things[i])
@@ -138,7 +144,7 @@ func TestExample__2(t *testing.T) {
 	// false
 }
 
-func TestExample__3(t *testing.T) {
+func TestStructConstructorAndMap(t *testing.T) {
 	const code = `
 	user2 = Person()
 	user2.Name = "John"
@@ -174,7 +180,7 @@ func TestExample__3(t *testing.T) {
 	// 2
 }
 
-func TestExample__4(t *testing.T) {
+func TestGoFunc(t *testing.T) {
 	const code = `
 	print(getHello(person))
 	`
@@ -200,7 +206,7 @@ func TestExample__4(t *testing.T) {
 	// Hello, Tim
 }
 
-func TestExample__5(t *testing.T) {
+func TestChan(t *testing.T) {
 	const code = `
 	print(ch:receive())
 	ch:send("John")
@@ -229,7 +235,7 @@ func TestExample__5(t *testing.T) {
 	// nil	false
 }
 
-func TestExample__6(t *testing.T) {
+func TestMap(t *testing.T) {
 	const code = `
 	local sorted = {}
 	for k, v in countries() do
@@ -261,7 +267,7 @@ func TestExample__6(t *testing.T) {
 	// Japan
 }
 
-func TestExample__7(t *testing.T) {
+func TestFuncVariadic(t *testing.T) {
 	const code = `
 	fn("a", 1, 2, 3)
 	fn("b")
@@ -293,7 +299,7 @@ func TestExample__7(t *testing.T) {
 	// 4
 }
 
-func TestExample__8(t *testing.T) {
+func TestLuaFuncVariadic(t *testing.T) {
 	const code = `
 	for _, x in ipairs(fn(1, 2, 3)) do
 		print(x)
@@ -329,7 +335,7 @@ func TestExample__8(t *testing.T) {
 	// 4
 }
 
-func TestExample__9(t *testing.T) {
+func TestSlice(t *testing.T) {
 	const code = `
 	print(#items)
 	print(items:capacity())
@@ -359,7 +365,7 @@ func TestExample__9(t *testing.T) {
 	// world
 }
 
-func TestExample__10(t *testing.T) {
+func TestSliceCapacity(t *testing.T) {
 	const code = `
 	ints = newInts(1)
 	print(#ints, ints:capacity())
@@ -383,7 +389,7 @@ func TestExample__10(t *testing.T) {
 	// 0	10
 }
 
-func TestExample__11(t *testing.T) {
+func TestStructPtrEquality(t *testing.T) {
 	const code = `
 	print(-p1 == -p1)
 	print(-p1 == -p1_alias)
@@ -417,7 +423,7 @@ func TestExample__11(t *testing.T) {
 	// false
 }
 
-func TestExample__12(t *testing.T) {
+func TestStructStringer(t *testing.T) {
 	const code = `
 	print(p1)
 	print(p2)
@@ -446,7 +452,7 @@ func TestExample__12(t *testing.T) {
 	// John (2)
 }
 
-func TestExample__13(t *testing.T) {
+func TestPtrMethod(t *testing.T) {
 	const code = `
 	print(p:AddNumbers(1, 2, 3, 4, 5))
 	`
@@ -467,7 +473,7 @@ func TestExample__13(t *testing.T) {
 	// Tim counts: 15
 }
 
-func TestExample__14(t *testing.T) {
+func TestStruct(t *testing.T) {
 	const code = `
 	print(p:hello())
 	print(p.age)
@@ -497,7 +503,7 @@ func (o OneString) Print() {
 	fmt.Println(o[0])
 }
 
-func TestExample__15(t *testing.T) {
+func TestArray(t *testing.T) {
 	const code = `
 	print(#e.V, e.V[1], e.V[2])
 	e.V[1] = "World"
@@ -535,7 +541,7 @@ func TestExample__15(t *testing.T) {
 	// Test
 }
 
-func TestExample__16(t *testing.T) {
+func TestLuaFunc(t *testing.T) {
 	const code = `
 	print(fn("tim", 5))
 	`
@@ -560,7 +566,7 @@ func TestExample__16(t *testing.T) {
 	// tim	tim	tim	tim	tim
 }
 
-func TestExample__17(t *testing.T) {
+func TestPtrIndirection(t *testing.T) {
 	const code = `
 	print(-ptr)
 	`
@@ -579,7 +585,7 @@ func TestExample__17(t *testing.T) {
 	// hello
 }
 
-func TestExample__18(t *testing.T) {
+func TestPtrEquality(t *testing.T) {
 	const code = `
 	print(ptr1 == nil)
 	print(ptr2 == nil)
@@ -604,7 +610,7 @@ func TestExample__18(t *testing.T) {
 	// false
 }
 
-func TestExample__19(t *testing.T) {
+func TestPtrAssignment(t *testing.T) {
 	const code = `
 	print(-str)
 	print(str ^ "world")
@@ -627,16 +633,16 @@ func TestExample__19(t *testing.T) {
 	// world
 }
 
-type Example__20_A struct {
-	*Example__20_B
+type AnonymousFieldsA struct {
+	*AnonymousFieldsB
 }
 
-type Example__20_B struct {
+type AnonymousFieldsB struct {
 	Value *string
 	Person
 }
 
-func TestExample__20(t *testing.T) {
+func TestAnonymousFields(t *testing.T) {
 	const code = `
 	print(a.Value == nil)
 	a.Value = str_ptr()
@@ -649,8 +655,8 @@ func TestExample__20(t *testing.T) {
 	L := lua.NewState()
 	defer L.Close()
 
-	a := Example__20_A{
-		Example__20_B: &Example__20_B{
+	a := AnonymousFieldsA{
+		AnonymousFieldsB: &AnonymousFieldsB{
 			Person: Person{
 				Name: "Tim",
 			},
@@ -670,7 +676,7 @@ func TestExample__20(t *testing.T) {
 	// Tim
 }
 
-func TestExample__21(t *testing.T) {
+func TestEmptyFunc(t *testing.T) {
 	const code = `
 	print(fn == nil)
 	`
@@ -689,7 +695,7 @@ func TestExample__21(t *testing.T) {
 	// true
 }
 
-func TestExample__22(t *testing.T) {
+func TestFuncArray(t *testing.T) {
 	const code = `
 	fn(arr)
 	`
@@ -712,7 +718,7 @@ func TestExample__22(t *testing.T) {
 	// 1 2 3
 }
 
-func TestExample__23(t *testing.T) {
+func TestComplex(t *testing.T) {
 	const code = `
 	b = a
 	`
@@ -758,7 +764,7 @@ func (m MapAlias) Y() int {
 	return len(m)
 }
 
-func TestExample__24(t *testing.T) {
+func TestTypeAlias(t *testing.T) {
 	const code = `
 	print(a:Test())
 	local len1 = b:Len()
@@ -789,18 +795,18 @@ func TestExample__24(t *testing.T) {
 	// 15	1
 }
 
-type E25B struct {
+type StructPtrFuncB struct {
 }
 
-func (*E25B) Test() {
+func (*StructPtrFuncB) Test() {
 	fmt.Println("Pointer test")
 }
 
-type E25A struct {
-	B E25B
+type StructPtrFuncA struct {
+	B StructPtrFuncB
 }
 
-func TestExample__25(t *testing.T) {
+func TestStructPtrFunc(t *testing.T) {
 	const code = `
 	a.b:Test()
 	`
@@ -808,7 +814,7 @@ func TestExample__25(t *testing.T) {
 	L := lua.NewState()
 	defer L.Close()
 
-	a := E25A{}
+	a := StructPtrFuncA{}
 	L.SetGlobal("a", New(L, &a))
 
 	if err := L.DoString(code); err != nil {
@@ -820,14 +826,14 @@ func TestExample__25(t *testing.T) {
 	// Pointer test
 }
 
-type E26A struct {
+type HiddenFieldNamesA struct {
 	Name   string `luar:"name"`
 	Name2  string `luar:"Name"`
 	Str    string
 	Hidden bool `luar:"-"`
 }
 
-func TestExample__26(t *testing.T) {
+func TestHiddenFieldNames(t *testing.T) {
 	const code = `
 	print(a.name)
 	print(a.Name)
@@ -840,7 +846,7 @@ func TestExample__26(t *testing.T) {
 	L := lua.NewState()
 	defer L.Close()
 
-	a := &E26A{
+	a := &HiddenFieldNamesA{
 		Name:   "tim",
 		Name2:  "bob",
 		Str:    "asd123",
@@ -861,7 +867,7 @@ func TestExample__26(t *testing.T) {
 	// nil
 }
 
-func TestExample__27(t *testing.T) {
+func TestStructPtrAssignment(t *testing.T) {
 	const code = `
 	print(a.Name)
 	_ = a ^ -b
@@ -889,17 +895,17 @@ func TestExample__27(t *testing.T) {
 	// bob
 }
 
-type E28_Chan chan string
+type PtrNonPtrChanMethodsA chan string
 
-func (*E28_Chan) Test() {
-	fmt.Println("E28_Chan.Test")
+func (*PtrNonPtrChanMethodsA) Test() {
+	fmt.Println("PtrNonPtrMethods_A.Test")
 }
 
-func (E28_Chan) Test2() {
-	fmt.Println("E28_Chan.Test2")
+func (PtrNonPtrChanMethodsA) Test2() {
+	fmt.Println("PtrNonPtrMethods_A.Test2")
 }
 
-func TestExample__28(t *testing.T) {
+func TestPtrNonPtrChanMethods(t *testing.T) {
 	const code = `
 	b:Test()
 	b:Test2()
@@ -908,7 +914,7 @@ func TestExample__28(t *testing.T) {
 	L := lua.NewState()
 	defer L.Close()
 
-	a := make(E28_Chan)
+	a := make(PtrNonPtrChanMethodsA)
 	b := &a
 
 	b.Test()
@@ -926,13 +932,13 @@ func TestExample__28(t *testing.T) {
 	// E28_Chan.Test2
 }
 
-type E29_String string
+type StructFieldA string
 
-type E29_A struct {
-	E29_String
+type StructFieldB struct {
+	StructFieldA
 }
 
-func TestExample__29(t *testing.T) {
+func TestStructField(t *testing.T) {
 	const code = `
 	a.E29_String = "world"
 	`
@@ -940,37 +946,37 @@ func TestExample__29(t *testing.T) {
 	L := lua.NewState()
 	defer L.Close()
 
-	a := E29_A{}
-	a.E29_String = "hello"
-	fmt.Println(a.E29_String)
+	a := StructFieldB{}
+	a.StructFieldA = "hello"
+	fmt.Println(a.StructFieldA)
 
 	L.SetGlobal("a", New(L, &a))
 
 	if err := L.DoString(code); err != nil {
 		t.Fatal(err)
 	}
-	fmt.Println(a.E29_String)
+	fmt.Println(a.StructFieldA)
 	// Output:
 	// hello
 	// world
 }
 
-type E30_A struct {
+type StructBlacklistA struct {
 }
 
-func (*E30_A) Public() {
+func (*StructBlacklistA) Public() {
 	fmt.Println("You can call me")
 }
 
-func (E30_A) Private() {
+func (StructBlacklistA) Private() {
 	fmt.Println("Should not be able to call me")
 }
 
-type E30_B struct {
-	*E30_A
+type StructBlacklistB struct {
+	*StructBlacklistA
 }
 
-func TestExample__30(t *testing.T) {
+func TestStructBlacklist(t *testing.T) {
 	const code = `
 	b:public()
 	b.E30_A:public()
@@ -995,14 +1001,14 @@ func TestExample__30(t *testing.T) {
 	L := lua.NewState()
 	defer L.Close()
 
-	b := &E30_B{
-		E30_A: &E30_A{},
+	b := &StructBlacklistB{
+		StructBlacklistA: &StructBlacklistA{},
 	}
 
-	mt := MT(L, E30_B{})
+	mt := MT(L, StructBlacklistB{})
 	mt.Blacklist("private", "Private")
 
-	mt = MT(L, E30_A{})
+	mt = MT(L, StructBlacklistA{})
 	mt.Whitelist("public", "Public")
 
 	L.SetGlobal("b", New(L, b))
@@ -1015,11 +1021,11 @@ func TestExample__30(t *testing.T) {
 	// You can call me
 }
 
-type E_31 struct {
+type SliceAssignmentA struct {
 	S []string
 }
 
-func TestExample__31(t *testing.T) {
+func TestSliceAssignment(t *testing.T) {
 	const code = `
 	x.S = {"a", "b", "", 3, true, "c"}
 	`
@@ -1027,7 +1033,7 @@ func TestExample__31(t *testing.T) {
 	L := lua.NewState()
 	defer L.Close()
 
-	e := &E_31{}
+	e := &SliceAssignmentA{}
 	L.SetGlobal("x", New(L, e))
 
 	if err := L.DoString(code); err != nil {
@@ -1045,11 +1051,11 @@ func TestExample__31(t *testing.T) {
 	// c
 }
 
-type E_32 struct {
+type SliceTableAssignmentA struct {
 	S map[string]string
 }
 
-func TestExample__32(t *testing.T) {
+func TestSliceTableAssignment(t *testing.T) {
 	const code = `
 	x.S = {
 		33,
@@ -1063,7 +1069,7 @@ func TestExample__32(t *testing.T) {
 	L := lua.NewState()
 	defer L.Close()
 
-	e := &E_32{}
+	e := &SliceTableAssignmentA{}
 	L.SetGlobal("x", New(L, e))
 
 	if err := L.DoString(code); err != nil {
@@ -1083,13 +1089,13 @@ func TestExample__32(t *testing.T) {
 	// false
 }
 
-type E_33 struct {
+type FieldNameResolutionA struct {
 	Person
 	P  Person
 	P2 Person `luar:"other"`
 }
 
-func TestExample__33(t *testing.T) {
+func TestFieldNameResolution(t *testing.T) {
 	const code = `
 	x.Person = {
 		Name = "Bill",
@@ -1112,7 +1118,7 @@ func TestExample__33(t *testing.T) {
 	L := lua.NewState()
 	defer L.Close()
 
-	e := &E_33{}
+	e := &FieldNameResolutionA{}
 	L.SetGlobal("x", New(L, e))
 
 	if err := L.DoString(code); err != nil {
@@ -1138,13 +1144,13 @@ func TestExample__33(t *testing.T) {
 	// 26
 }
 
-type E_34 struct {
+type PCallA struct {
 	A string `luar:"q"`
 	B int    `luar:"other"`
 	C int    `luar:"-"`
 }
 
-func TestExample__34(t *testing.T) {
+func TestPCall(t *testing.T) {
 	const code = `
 	_ = x ^ {
 		q = "Cat",
@@ -1160,7 +1166,7 @@ func TestExample__34(t *testing.T) {
 	L := lua.NewState()
 	defer L.Close()
 
-	e := &E_34{}
+	e := &PCallA{}
 	L.SetGlobal("x", New(L, e))
 
 	if err := L.DoString(code); err != nil {
@@ -1176,12 +1182,12 @@ func TestExample__34(t *testing.T) {
 	// 0
 }
 
-type E_35 struct {
+type LuaFuncDefinitionA struct {
 	Fn  func(a string) (string, int)
 	Fn2 func(a string, b ...int) string
 }
 
-func TestExample__35(t *testing.T) {
+func TestLuaFuncDefinition(t *testing.T) {
 	const code = `
 	i = 0
 	x.Fn = function(str)
@@ -1200,7 +1206,7 @@ func TestExample__35(t *testing.T) {
 	L := lua.NewState()
 	defer L.Close()
 
-	e := &E_35{}
+	e := &LuaFuncDefinitionA{}
 	L.SetGlobal("x", New(L, e))
 
 	if err := L.DoString(code); err != nil {
@@ -1226,11 +1232,11 @@ func TestExample__35(t *testing.T) {
 	// hello
 }
 
-type E_36 struct {
+type LuaFuncPtrA struct {
 	F1 *lua.LFunction
 }
 
-func TestExample__36(t *testing.T) {
+func TestLuaFuncPtr(t *testing.T) {
 	const code = `
 	x.F1 = function(str)
 		print("Hello World")
@@ -1240,7 +1246,7 @@ func TestExample__36(t *testing.T) {
 	L := lua.NewState()
 	defer L.Close()
 
-	e := &E_36{}
+	e := &LuaFuncPtrA{}
 	L.SetGlobal("x", New(L, e))
 
 	if err := L.DoString(code); err != nil {
@@ -1254,7 +1260,7 @@ func TestExample__36(t *testing.T) {
 	// Hello World
 }
 
-func TestExample__37(t *testing.T) {
+func TestSliceAndArrayTypes(t *testing.T) {
 	const code = `
 	for i, x in s() do
 		print(i, x)
@@ -1302,13 +1308,13 @@ func TestExample__37(t *testing.T) {
 	// 2	y
 }
 
-type E38String string
+type StructArrayAndSliceA string
 
-func (s *E38String) ToUpper() {
-	*s = E38String(strings.ToUpper(string(*s)))
+func (s *StructArrayAndSliceA) ToUpper() {
+	*s = StructArrayAndSliceA(strings.ToUpper(string(*s)))
 }
 
-func TestExample__38(t *testing.T) {
+func TestStructArrayAndSlice(t *testing.T) {
 	const code = `
 	print(a[1]:AddNumbers(1, 2, 3, 4, 5))
 	print(s[1]:AddNumbers(1, 2, 3, 4))
@@ -1335,7 +1341,7 @@ func TestExample__38(t *testing.T) {
 		{Name: "Tim", Age: 32},
 	}
 
-	str := E38String("Hello World")
+	str := StructArrayAndSliceA("Hello World")
 
 	L.SetGlobal("a", New(L, &a))
 	L.SetGlobal("s", New(L, s))
@@ -1358,7 +1364,7 @@ func TestExample__38(t *testing.T) {
 	// HELLO WORLD
 }
 
-func TestExampleLState(t *testing.T) {
+func TestLStateFunc(t *testing.T) {
 	const code = `
 	print(sum(1, 2, 3, 4, 5))
 	`
@@ -1384,7 +1390,7 @@ func TestExampleLState(t *testing.T) {
 	// 15
 }
 
-func TestExampleNewType(t *testing.T) {
+func TestNewType(t *testing.T) {
 	L := lua.NewState()
 	defer L.Close()
 
@@ -1404,7 +1410,7 @@ func TestExampleNewType(t *testing.T) {
 	// Tycho - Montana
 }
 
-func TestExample__Immutable1(t *testing.T) {
+func TestImmutableStructFieldModify(t *testing.T) {
 	// Modifying a field on an immutable struct - should error
 	const code = `
 	p.Name = "Tom"
@@ -1429,7 +1435,7 @@ func TestExample__Immutable1(t *testing.T) {
 	}
 }
 
-func TestExample__Immutable2(t *testing.T) {
+func TestImmutableStructPtrFunc(t *testing.T) {
 	// Calling a pointer function on an immutable struct - should error
 	const code = `
 	p:IncreaseAge()
@@ -1454,7 +1460,7 @@ func TestExample__Immutable2(t *testing.T) {
 	}
 }
 
-func TestExample__Immutable3(t *testing.T) {
+func TestImmutableStructFieldAccess(t *testing.T) {
 	// Accessing a field and calling a regular function on an immutable
 	// struct - should be fine
 	const code = `
@@ -1477,7 +1483,7 @@ func TestExample__Immutable3(t *testing.T) {
 	}
 }
 
-func TestExample__Immutable4(t *testing.T) {
+func TestImmutableSliceAssignment(t *testing.T) {
 	// Attempting to modify an immutable slice - should error
 	const code = `
 	s[1] = "hi"
@@ -1498,7 +1504,7 @@ func TestExample__Immutable4(t *testing.T) {
 	}
 }
 
-func TestExample__Immutable5(t *testing.T) {
+func TestImmutableSliceAppend(t *testing.T) {
 	// Attempting to append to an immutable slice - should error
 	const code = `
 	s = s:append("hi")
@@ -1519,7 +1525,7 @@ func TestExample__Immutable5(t *testing.T) {
 	}
 }
 
-func TestExample__Immutable6(t *testing.T) {
+func TestImmutableSliceAccess(t *testing.T) {
 	// Attempting to access a member of an immutable slice - should be fine
 	const code = `
 	print(s[1])
@@ -1536,7 +1542,7 @@ func TestExample__Immutable6(t *testing.T) {
 	}
 }
 
-func TestExample__Immutable7(t *testing.T) {
+func TestImmutableMapAssignment(t *testing.T) {
 	// Attempting to modify an immutable map - should error
 	const code = `
 	m["newKey"] = "hi"
@@ -1557,7 +1563,7 @@ func TestExample__Immutable7(t *testing.T) {
 	}
 }
 
-func TestExample__Immutable8(t *testing.T) {
+func TestImmutableMapAccess(t *testing.T) {
 	// Attempting to access a member of an immutable map - should be fine
 	const code = `
 	print(m["first"])
@@ -1574,13 +1580,7 @@ func TestExample__Immutable8(t *testing.T) {
 	}
 }
 
-type Family struct {
-	Mother   Person
-	Father   Person
-	Children []Person
-}
-
-func TestExample__Immutable9(t *testing.T) {
+func TestImmutableNestedStructField(t *testing.T) {
 	// Attempt to modify a nested field on an immutable struct - should error
 	const code = `
 	f.Mother.Name = "Laura"
@@ -1609,7 +1609,7 @@ func TestExample__Immutable9(t *testing.T) {
 	}
 }
 
-func TestExample__Immutable10(t *testing.T) {
+func TestImmutableNestedStructSliceField(t *testing.T) {
 	// Attempt to modify a nested field in a nested slice, on an immutable
 	// struct - should error
 	const code = `
@@ -1642,7 +1642,7 @@ func TestExample__Immutable10(t *testing.T) {
 	}
 }
 
-func TestExample__Immutable11(t *testing.T) {
+func TestImmutableNestedStructPtrSliceField(t *testing.T) {
 	// Attempt to modify a nested field in a nested slice, on an immutable
 	// struct pointer - should error
 	const code = `
@@ -1675,7 +1675,7 @@ func TestExample__Immutable11(t *testing.T) {
 	}
 }
 
-func TestExample__Immutable12(t *testing.T) {
+func TestImmutablePointerAssignment(t *testing.T) {
 	// Attempt to modify the value of an immutable pointer - should error
 	const code = `
 	_ = str ^ "world"
@@ -1697,7 +1697,7 @@ func TestExample__Immutable12(t *testing.T) {
 	}
 }
 
-func TestExample__Immutable13(t *testing.T) {
+func TestImmutablePointerAccess(t *testing.T) {
 	// Attempt to access the value of an immutable pointer - should be fine
 	const code = `
 	print(-str)
@@ -1715,15 +1715,15 @@ func TestExample__Immutable13(t *testing.T) {
 	}
 }
 
-type TransparentSample struct {
+type TransparentPtrAccessA struct {
 	B *string
 }
 
-type TransparentSampleWrapper struct {
-	A *TransparentSample
+type TransparentPtrAccessB struct {
+	A *TransparentPtrAccessA
 }
 
-func TestExample__TransparentPointers1(t *testing.T) {
+func TestTransparentPtrAccess(t *testing.T) {
 	// Access an undefined pointer field - should auto populate with zero
 	// value as if a non-pointer object
 	const code = `
@@ -1733,7 +1733,7 @@ func TestExample__TransparentPointers1(t *testing.T) {
 	L := lua.NewState()
 	defer L.Close()
 
-	a := TransparentSample{}
+	a := TransparentPtrAccessA{}
 
 	L.SetGlobal("a", NewWithOptions(L, &a, ReflectOptions{TransparentPointers: true}))
 
@@ -1745,7 +1745,7 @@ func TestExample__TransparentPointers1(t *testing.T) {
 	//
 }
 
-func TestExample__TransparentPointers2(t *testing.T) {
+func TestTransparentNestedStructPtrAccess(t *testing.T) {
 	// Access an undefined nested pointer field - should auto populate
 	// with zero values as if a non-pointer object
 	const code = `
@@ -1755,7 +1755,7 @@ func TestExample__TransparentPointers2(t *testing.T) {
 	L := lua.NewState()
 	defer L.Close()
 
-	s := TransparentSampleWrapper{}
+	s := TransparentPtrAccessB{}
 
 	L.SetGlobal("s", NewWithOptions(L, &s, ReflectOptions{TransparentPointers: true}))
 
@@ -1767,7 +1767,7 @@ func TestExample__TransparentPointers2(t *testing.T) {
 	//
 }
 
-func TestExample__TransparentPointers3(t *testing.T) {
+func TestTransparentNestedStructPtrAssignment(t *testing.T) {
 	// Set an undefined nested pointer field - should get assigned like
 	// a regular non-pointer field
 	const code = `
@@ -1778,7 +1778,7 @@ func TestExample__TransparentPointers3(t *testing.T) {
 	L := lua.NewState()
 	defer L.Close()
 
-	s := TransparentSampleWrapper{}
+	s := TransparentPtrAccessB{}
 
 	L.SetGlobal("s", NewWithOptions(L, &s, ReflectOptions{TransparentPointers: true}))
 
@@ -1790,7 +1790,7 @@ func TestExample__TransparentPointers3(t *testing.T) {
 	// hello, world!
 }
 
-func TestExample__TransparentPointers4(t *testing.T) {
+func TestTransparentPtrEquality(t *testing.T) {
 	// Check equality on a pointer field - should act like a plain field
 	const code = `
 	print(a.B == "foo")
@@ -1799,7 +1799,7 @@ func TestExample__TransparentPointers4(t *testing.T) {
 	L := lua.NewState()
 	defer L.Close()
 
-	a := TransparentSample{}
+	a := TransparentPtrAccessA{}
 	val := "foo"
 	a.B = &val
 
@@ -1813,7 +1813,7 @@ func TestExample__TransparentPointers4(t *testing.T) {
 	// true
 }
 
-func TestExample__TransparentPointers5(t *testing.T) {
+func TestTransparentPtrPowOp(t *testing.T) {
 	// Access a pointer field in the normal pointer way - should error
 	const code = `
 	_ = a.B ^ "hello"
@@ -1822,7 +1822,7 @@ func TestExample__TransparentPointers5(t *testing.T) {
 	L := lua.NewState()
 	defer L.Close()
 
-	a := TransparentSample{}
+	a := TransparentPtrAccessA{}
 	val := "foo"
 	a.B = &val
 
@@ -1837,11 +1837,11 @@ func TestExample__TransparentPointers5(t *testing.T) {
 	}
 }
 
-type SampleStructWithSlice struct {
+type TransparentStructSliceFieldA struct {
 	List []string
 }
 
-func TestExample__TransparentPointers6(t *testing.T) {
+func TestTransparentStructSliceField(t *testing.T) {
 	// Access an undefined slice field - should be automatically created
 	const code = `
 	print(#a.List)
@@ -1850,7 +1850,7 @@ func TestExample__TransparentPointers6(t *testing.T) {
 	L := lua.NewState()
 	defer L.Close()
 
-	a := SampleStructWithSlice{}
+	a := TransparentStructSliceFieldA{}
 
 	L.SetGlobal("a", NewWithOptions(L, &a, ReflectOptions{TransparentPointers: true}))
 
@@ -1862,7 +1862,7 @@ func TestExample__TransparentPointers6(t *testing.T) {
 	// 0
 }
 
-func TestExample__TransparentPointers7(t *testing.T) {
+func TestTransparentStructSliceAppend(t *testing.T) {
 	// Append to an undefined slice field - should be fine
 	const code = `
 	a.List = a.List:append("hi")
@@ -1872,7 +1872,7 @@ func TestExample__TransparentPointers7(t *testing.T) {
 	L := lua.NewState()
 	defer L.Close()
 
-	a := SampleStructWithSlice{}
+	a := TransparentStructSliceFieldA{}
 
 	L.SetGlobal("a", NewWithOptions(L, &a, ReflectOptions{TransparentPointers: true}))
 

--- a/example_test.go
+++ b/example_test.go
@@ -77,6 +77,13 @@ func newOutputLogger() *outputLogger {
 	return &outputLogger{[]string{}}
 }
 
+func newStateWithLogger() (*lua.LState, *outputLogger) {
+	L := lua.NewState()
+	logger := newOutputLogger()
+	L.SetGlobal("log", New(L, logger.Log))
+	return L, logger
+}
+
 func TestStructUsage(t *testing.T) {
 	const code = `
 	log(user1.Name)
@@ -89,11 +96,8 @@ func TestStructUsage(t *testing.T) {
 	log(hello(user2))
 	`
 
-	L := lua.NewState()
+	L, logger := newStateWithLogger()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	tim := &Person{
 		Name: "Tim",
@@ -142,11 +146,8 @@ func TestMapAndSlice(t *testing.T) {
 	thangs.ABC = nil
 	`
 
-	L := lua.NewState()
+	L, logger := newStateWithLogger()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	things := []string{
 		"cake",
@@ -208,11 +209,8 @@ func TestStructConstructorAndMap(t *testing.T) {
 	everyone["john"] = user2
 	`
 
-	L := lua.NewState()
+	L, logger := newStateWithLogger()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	tim := &Person{
 		Name: "Tim",
@@ -245,11 +243,8 @@ func TestGoFunc(t *testing.T) {
 	log(getHello(person))
 	`
 
-	L := lua.NewState()
+	L, logger := newStateWithLogger()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	tim := &Person{
 		Name: "Tim",
@@ -282,11 +277,8 @@ func TestChan(t *testing.T) {
 	log(ch:receive())
 	`
 
-	L := lua.NewState()
+	L, logger := newStateWithLogger()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	ch := make(chan string)
 	go func() {
@@ -325,11 +317,8 @@ func TestMap(t *testing.T) {
 	end
 	`
 
-	L := lua.NewState()
+	L, logger := newStateWithLogger()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	countries := map[string]string{
 		"JP": "Japan",
@@ -361,11 +350,8 @@ func TestFuncVariadic(t *testing.T) {
 	fn("c", 4)
 	`
 
-	L := lua.NewState()
+	L, logger := newStateWithLogger()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	fn := func(str string, extra ...int) {
 		logger.Log(str)
@@ -408,11 +394,8 @@ func TestLuaFuncVariadic(t *testing.T) {
 	end
 	`
 
-	L := lua.NewState()
+	L, logger := newStateWithLogger()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	fn := func(x ...float64) *lua.LTable {
 		tbl := L.NewTable()
@@ -451,11 +434,8 @@ func TestSlice(t *testing.T) {
 	log(items[2])
 	`
 
-	L := lua.NewState()
+	L, logger := newStateWithLogger()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	items := make([]string, 0, 10)
 
@@ -488,11 +468,8 @@ func TestSliceCapacity(t *testing.T) {
 	log(#ints, ints:capacity())
 	`
 
-	L := lua.NewState()
+	L, logger := newStateWithLogger()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	type ints []int
 
@@ -521,11 +498,8 @@ func TestStructPtrEquality(t *testing.T) {
 	log(p1 == p2)
 	`
 
-	L := lua.NewState()
+	L, logger := newStateWithLogger()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	p1 := Person{
 		Name: "Tim",
@@ -561,11 +535,8 @@ func TestStructStringer(t *testing.T) {
 	log(p2)
 	`
 
-	L := lua.NewState()
+	L, logger := newStateWithLogger()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	p1 := Person{
 		Name: "Tim",
@@ -598,11 +569,8 @@ func TestPtrMethod(t *testing.T) {
 	log(p:AddNumbers(1, 2, 3, 4, 5))
 	`
 
-	L := lua.NewState()
+	L, logger := newStateWithLogger()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	p := Person{
 		Name: "Tim",
@@ -629,11 +597,8 @@ func TestStruct(t *testing.T) {
 	log(p.age)
 	`
 
-	L := lua.NewState()
+	L, logger := newStateWithLogger()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	p := Person{
 		Name: "Tim",
@@ -677,11 +642,8 @@ func TestArray(t *testing.T) {
 		V [2]string
 	}
 
-	L := lua.NewState()
+	L, logger := newStateWithLogger()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	var elem Elem
 	elem.V[0] = "Hello"
@@ -714,11 +676,8 @@ func TestLuaFunc(t *testing.T) {
 	log(fn("tim", 5))
 	`
 
-	L := lua.NewState()
+	L, logger := newStateWithLogger()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	fn := func(name string, count int) []lua.LValue {
 		s := make([]lua.LValue, count)
@@ -748,11 +707,8 @@ func TestPtrIndirection(t *testing.T) {
 	log(-ptr)
 	`
 
-	L := lua.NewState()
+	L, logger := newStateWithLogger()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	str := "hello"
 
@@ -778,11 +734,8 @@ func TestPtrEquality(t *testing.T) {
 	log(ptr1 == ptr2)
 	`
 
-	L := lua.NewState()
+	L, logger := newStateWithLogger()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	var ptr1 *string
 	str := "hello"
@@ -812,11 +765,8 @@ func TestPtrAssignment(t *testing.T) {
 	log(-str)
 	`
 
-	L := lua.NewState()
+	L, logger := newStateWithLogger()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	str := "hello"
 
@@ -856,11 +806,8 @@ func TestAnonymousFields(t *testing.T) {
 	log(a.Name)
 	`
 
-	L := lua.NewState()
+	L, logger := newStateWithLogger()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	a := AnonymousFieldsA{
 		AnonymousFieldsB: &AnonymousFieldsB{
@@ -894,11 +841,8 @@ func TestEmptyFunc(t *testing.T) {
 	log(fn == nil)
 	`
 
-	L := lua.NewState()
+	L, logger := newStateWithLogger()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	var fn func()
 
@@ -922,11 +866,8 @@ func TestFuncArray(t *testing.T) {
 	fn(arr)
 	`
 
-	L := lua.NewState()
+	L, logger := newStateWithLogger()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	arr := [3]int{1, 2, 3}
 	fn := func(val [3]int) {
@@ -954,11 +895,8 @@ func TestComplex(t *testing.T) {
 	b = a
 	`
 
-	L := lua.NewState()
+	L, logger := newStateWithLogger()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	a := complex(float64(1), float64(2))
 
@@ -1013,11 +951,8 @@ func TestTypeAlias(t *testing.T) {
 	log(c.x, c:y())
 	`
 
-	L := lua.NewState()
+	L, logger := newStateWithLogger()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	a := make(ChanAlias)
 	var b SliceAlias = []string{"Hello", "world"}
@@ -1060,11 +995,8 @@ func TestStructPtrFunc(t *testing.T) {
 	log(a.b:Test())
 	`
 
-	L := lua.NewState()
+	L, logger := newStateWithLogger()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	a := StructPtrFuncA{}
 	L.SetGlobal("a", New(L, &a))
@@ -1101,11 +1033,8 @@ func TestHiddenFieldNames(t *testing.T) {
 	log(a.hidden)
 	`
 
-	L := lua.NewState()
+	L, logger := newStateWithLogger()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	a := &HiddenFieldNamesA{
 		Name:   "tim",
@@ -1141,11 +1070,8 @@ func TestStructPtrAssignment(t *testing.T) {
 	log(a.Name)
 	`
 
-	L := lua.NewState()
+	L, logger := newStateWithLogger()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	a := &Person{
 		Name: "tim",
@@ -1187,11 +1113,8 @@ func TestPtrNonPtrChanMethods(t *testing.T) {
 	log(b:Test2())
 	`
 
-	L := lua.NewState()
+	L, logger := newStateWithLogger()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	a := make(PtrNonPtrChanMethodsA)
 	b := &a
@@ -1228,11 +1151,8 @@ func TestStructField(t *testing.T) {
 	a.StructFieldA = "world"
 	`
 
-	L := lua.NewState()
+	L, logger := newStateWithLogger()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	a := StructFieldB{}
 	a.StructFieldA = "hello"
@@ -1292,11 +1212,8 @@ func TestStructBlacklist(t *testing.T) {
 	end)
 	`
 
-	L := lua.NewState()
+	L, logger := newStateWithLogger()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	b := &StructBlacklistB{
 		StructBlacklistA: &StructBlacklistA{},
@@ -1333,11 +1250,8 @@ func TestSliceAssignment(t *testing.T) {
 	x.S = {"a", "b", "", 3, true, "c"}
 	`
 
-	L := lua.NewState()
+	L, logger := newStateWithLogger()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	e := &SliceAssignmentA{}
 	L.SetGlobal("x", New(L, e))
@@ -1378,11 +1292,8 @@ func TestSliceTableAssignment(t *testing.T) {
 	}
 	`
 
-	L := lua.NewState()
+	L, logger := newStateWithLogger()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	e := &SliceTableAssignmentA{}
 	L.SetGlobal("x", New(L, e))
@@ -1436,11 +1347,8 @@ func TestFieldNameResolution(t *testing.T) {
 	}
 	`
 
-	L := lua.NewState()
+	L, logger := newStateWithLogger()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	e := &FieldNameResolutionA{}
 	L.SetGlobal("x", New(L, e))
@@ -1493,11 +1401,8 @@ func TestPCall(t *testing.T) {
 	end)
 	`
 
-	L := lua.NewState()
+	L, logger := newStateWithLogger()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	e := &PCallA{}
 	L.SetGlobal("x", New(L, e))
@@ -1542,11 +1447,8 @@ func TestLuaFuncDefinition(t *testing.T) {
 	end
 	`
 
-	L := lua.NewState()
+	L, logger := newStateWithLogger()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	e := &LuaFuncDefinitionA{}
 	L.SetGlobal("x", New(L, e))
@@ -1591,11 +1493,8 @@ func TestLuaFuncPtr(t *testing.T) {
 	end
 	`
 
-	L := lua.NewState()
+	L, logger := newStateWithLogger()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	e := &LuaFuncPtrA{}
 	L.SetGlobal("x", New(L, e))
@@ -1633,11 +1532,8 @@ func TestSliceAndArrayTypes(t *testing.T) {
 	end
 	`
 
-	L := lua.NewState()
+	L, logger := newStateWithLogger()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	s := []string{
 		"hello",
@@ -1697,11 +1593,8 @@ func TestStructArrayAndSlice(t *testing.T) {
 	log(-str)
 	`
 
-	L := lua.NewState()
+	L, logger := newStateWithLogger()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	a := [...]Person{
 		{Name: "Tim"},
@@ -1744,11 +1637,8 @@ func TestLStateFunc(t *testing.T) {
 	log(sum(1, 2, 3, 4, 5))
 	`
 
-	L := lua.NewState()
+	L, logger := newStateWithLogger()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	sum := func(L *LState) int {
 		total := 0
@@ -1775,11 +1665,8 @@ func TestLStateFunc(t *testing.T) {
 }
 
 func TestNewType(t *testing.T) {
-	L := lua.NewState()
+	L, logger := newStateWithLogger()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	type Song struct {
 		Title  string
@@ -1812,9 +1699,6 @@ func TestImmutableStructFieldModify(t *testing.T) {
 	L := lua.NewState()
 	defer L.Close()
 
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
-
 	p := Person{
 		Name: "Tim",
 		Age:  66,
@@ -1840,9 +1724,6 @@ func TestImmutableStructPtrFunc(t *testing.T) {
 	L := lua.NewState()
 	defer L.Close()
 
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
-
 	p := Person{
 		Name: "Tim",
 		Age:  66,
@@ -1863,15 +1744,12 @@ func TestImmutableStructFieldAccess(t *testing.T) {
 	// Accessing a field and calling a regular function on an immutable
 	// struct - should be fine
 	const code = `
-	p:Hello()
+	log(p:Hello())
 	log(p.Name)
 	`
 
-	L := lua.NewState()
+	L, logger := newStateWithLogger()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	p := Person{
 		Name: "Tim",
@@ -1883,6 +1761,15 @@ func TestImmutableStructFieldAccess(t *testing.T) {
 	if err := L.DoString(code); err != nil {
 		t.Fatal(err)
 	}
+
+	expected := []string{
+		"Hello, Tim",
+		"Tim",
+	}
+
+	if !logger.Equals(expected) {
+		t.Fatalf("Unexpected output. Expected:\n%s\n\nActual:\n%s", expected, logger.Lines)
+	}
 }
 
 func TestImmutableSliceAssignment(t *testing.T) {
@@ -1893,9 +1780,6 @@ func TestImmutableSliceAssignment(t *testing.T) {
 
 	L := lua.NewState()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	s := []string{"first", "second"}
 	L.SetGlobal("s", New(L, s, ReflectOptions{Immutable: true}))
@@ -1916,10 +1800,6 @@ func TestImmutableSliceAppend(t *testing.T) {
 	`
 
 	L := lua.NewState()
-	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	s := []string{"first", "second"}
 	L.SetGlobal("s", New(L, s, ReflectOptions{Immutable: true}))
@@ -1939,17 +1819,22 @@ func TestImmutableSliceAccess(t *testing.T) {
 	log(s[1])
 	`
 
-	L := lua.NewState()
+	L, logger := newStateWithLogger()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	s := []string{"first", "second"}
 	L.SetGlobal("s", New(L, s, ReflectOptions{Immutable: true}))
 
 	if err := L.DoString(code); err != nil {
 		t.Fatal(err)
+	}
+
+	expected := []string{
+		"first",
+	}
+
+	if !logger.Equals(expected) {
+		t.Fatalf("Unexpected output. Expected:\n%s\n\nActual:\n%s", expected, logger.Lines)
 	}
 }
 
@@ -1961,9 +1846,6 @@ func TestImmutableMapAssignment(t *testing.T) {
 
 	L := lua.NewState()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	m := map[string]string{"first": "foo", "second": "bar"}
 	L.SetGlobal("m", New(L, m, ReflectOptions{Immutable: true}))
@@ -1983,17 +1865,22 @@ func TestImmutableMapAccess(t *testing.T) {
 	log(m["first"])
 	`
 
-	L := lua.NewState()
+	L, logger := newStateWithLogger()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	m := map[string]string{"first": "foo", "second": "bar"}
 	L.SetGlobal("m", New(L, m, ReflectOptions{Immutable: true}))
 
 	if err := L.DoString(code); err != nil {
 		t.Fatal(err)
+	}
+
+	expected := []string{
+		"foo",
+	}
+
+	if !logger.Equals(expected) {
+		t.Fatalf("Unexpected output. Expected:\n%s\n\nActual:\n%s", expected, logger.Lines)
 	}
 }
 
@@ -2005,9 +1892,6 @@ func TestImmutableNestedStructField(t *testing.T) {
 
 	L := lua.NewState()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	f := Family{
 		Mother: Person{
@@ -2040,9 +1924,6 @@ func TestImmutableNestedStructFieldVar(t *testing.T) {
 	L := lua.NewState()
 	defer L.Close()
 
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
-
 	f := Family{
 		Mother: Person{
 			Name: "Luara",
@@ -2072,9 +1953,6 @@ func TestImmutableNestedStructSliceField(t *testing.T) {
 
 	L := lua.NewState()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	f := Family{
 		Mother: Person{
@@ -2109,9 +1987,6 @@ func TestImmutableNestedStructPtrSliceField(t *testing.T) {
 	L := lua.NewState()
 	defer L.Close()
 
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
-
 	f := Family{
 		Mother: Person{
 			Name: "Luara",
@@ -2144,9 +2019,6 @@ func TestImmutablePointerAssignment(t *testing.T) {
 	L := lua.NewState()
 	defer L.Close()
 
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
-
 	str := "hello"
 
 	L.SetGlobal("str", New(L, &str, ReflectOptions{Immutable: true}))
@@ -2166,11 +2038,8 @@ func TestImmutablePointerAccess(t *testing.T) {
 	log(-str)
 	`
 
-	L := lua.NewState()
+	L, logger := newStateWithLogger()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	str := "hello"
 
@@ -2178,6 +2047,14 @@ func TestImmutablePointerAccess(t *testing.T) {
 
 	if err := L.DoString(code); err != nil {
 		t.Fatal(err)
+	}
+
+	expected := []string{
+		"hello",
+	}
+
+	if !logger.Equals(expected) {
+		t.Fatalf("Unexpected output. Expected:\n%s\n\nActual:\n%s", expected, logger.Lines)
 	}
 }
 
@@ -2196,11 +2073,8 @@ func TestTransparentPtrAccess(t *testing.T) {
 	log(b.Str)
 	`
 
-	L := lua.NewState()
+	L, logger := newStateWithLogger()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	val := "foo"
 	b := TransparentPtrAccessB{}
@@ -2236,11 +2110,8 @@ func TestTransparentPtrAssignment(t *testing.T) {
 	log(a.B.Str)
 	`
 
-	L := lua.NewState()
+	L, logger := newStateWithLogger()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	val := "assigned ptr value"
 	a := TransparentPtrAccessA{}
@@ -2273,11 +2144,8 @@ func TestTransparentNestedStructPtrAccess(t *testing.T) {
 	log(a.B.Str)
 	`
 
-	L := lua.NewState()
+	L, logger := newStateWithLogger()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	a := TransparentPtrAccessA{}
 
@@ -2304,11 +2172,8 @@ func TestTransparentNestedStructPtrAssignment(t *testing.T) {
 	log(a.B.Str)
 	`
 
-	L := lua.NewState()
+	L, logger := newStateWithLogger()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	a := TransparentPtrAccessA{}
 
@@ -2333,11 +2198,8 @@ func TestTransparentPtrEquality(t *testing.T) {
 	log(b.Str == "foo")
 	`
 
-	L := lua.NewState()
+	L, logger := newStateWithLogger()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	b := TransparentPtrAccessB{}
 	val := "foo"
@@ -2368,9 +2230,6 @@ func TestTransparentPtrPowOp(t *testing.T) {
 	L := lua.NewState()
 	defer L.Close()
 
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
-
 	b := TransparentPtrAccessB{}
 	val := "foo"
 	b.Str = &val
@@ -2396,11 +2255,8 @@ func TestTransparentStructSliceField(t *testing.T) {
 	log(#a.List)
 	`
 
-	L := lua.NewState()
+	L, logger := newStateWithLogger()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	a := TransparentStructSliceFieldA{}
 
@@ -2427,11 +2283,8 @@ func TestTransparentStructSliceAppend(t *testing.T) {
 	log(#a.List)
 	`
 
-	L := lua.NewState()
+	L, logger := newStateWithLogger()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	a := TransparentStructSliceFieldA{}
 
@@ -2458,11 +2311,8 @@ func TestTransparentNestedStructVar(t *testing.T) {
 	log(b.Str)
 	`
 
-	L := lua.NewState()
+	L, logger := newStateWithLogger()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	val := "hello, world!"
 	a := TransparentPtrAccessA{
@@ -2494,11 +2344,8 @@ func TestTransparentSliceElementVar(t *testing.T) {
 	`
 
 	val := "hello, world!"
-	L := lua.NewState()
+	L, logger := newStateWithLogger()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	list := []TransparentPtrAccessA{
 		{&TransparentPtrAccessB{&val}},
@@ -2527,11 +2374,8 @@ func TestImmutableTransparentPtrFieldAccess(t *testing.T) {
 	log(b.Str)
 	`
 
-	L := lua.NewState()
+	L, logger := newStateWithLogger()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	val := "foo"
 	b := TransparentPtrAccessB{}
@@ -2561,9 +2405,6 @@ func TestImmutableTransparentPtrFieldAssignment(t *testing.T) {
 
 	L := lua.NewState()
 	defer L.Close()
-
-	logger := newOutputLogger()
-	L.SetGlobal("log", New(L, logger.Log))
 
 	val := "foo"
 	b := TransparentPtrAccessB{}

--- a/example_test.go
+++ b/example_test.go
@@ -1575,8 +1575,8 @@ func TestExample__Immutable8(t *testing.T) {
 }
 
 type Family struct {
-	Mother Person
-	Father Person
+	Mother   Person
+	Father   Person
 	Children []Person
 }
 
@@ -1627,7 +1627,7 @@ func TestExample__Immutable10(t *testing.T) {
 			Name: "Tim",
 		},
 		Children: []Person{
-			{ Name: "Bill" },
+			{Name: "Bill"},
 		},
 	}
 
@@ -1660,7 +1660,7 @@ func TestExample__Immutable11(t *testing.T) {
 			Name: "Tim",
 		},
 		Children: []Person{
-			{ Name: "Bill" },
+			{Name: "Bill"},
 		},
 	}
 

--- a/example_test.go
+++ b/example_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"testing"
 
 	"github.com/yuin/gopher-lua"
 )
@@ -37,7 +38,7 @@ func (p *Person) IncreaseAge() {
 	p.Age++
 }
 
-func Example__1() {
+func TestExample__1(t *testing.T) {
 	const code = `
 	print(user1.Name)
 	print(user1.Age)
@@ -66,7 +67,7 @@ func Example__1() {
 	L.SetGlobal("user2", New(L, john))
 
 	if err := L.DoString(code); err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	// Output:
 	// Tim
@@ -77,7 +78,7 @@ func Example__1() {
 	// Hello, John
 }
 
-func Example__2() {
+func TestExample__2(t *testing.T) {
 	const code = `
 	for i = 1, #things do
 		print(things[i])
@@ -113,7 +114,7 @@ func Example__2() {
 	L.SetGlobal("thangs", New(L, thangs))
 
 	if err := L.DoString(code); err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 
 	fmt.Println()
@@ -137,7 +138,7 @@ func Example__2() {
 	// false
 }
 
-func Example__3() {
+func TestExample__3(t *testing.T) {
 	const code = `
 	user2 = Person()
 	user2.Name = "John"
@@ -162,7 +163,7 @@ func Example__3() {
 	L.SetGlobal("People", NewType(L, map[string]*Person{}))
 
 	if err := L.DoString(code); err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 
 	everyone := L.GetGlobal("everyone").(*lua.LUserData).Value.(map[string]*Person)
@@ -173,7 +174,7 @@ func Example__3() {
 	// 2
 }
 
-func Example__4() {
+func TestExample__4(t *testing.T) {
 	const code = `
 	print(getHello(person))
 	`
@@ -193,13 +194,13 @@ func Example__4() {
 	L.SetGlobal("getHello", New(L, fn))
 
 	if err := L.DoString(code); err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	// Output:
 	// Hello, Tim
 }
 
-func Example__5() {
+func TestExample__5(t *testing.T) {
 	const code = `
 	print(ch:receive())
 	ch:send("John")
@@ -220,7 +221,7 @@ func Example__5() {
 	L.SetGlobal("ch", New(L, ch))
 
 	if err := L.DoString(code); err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	// Output:
 	// Tim	true
@@ -228,7 +229,7 @@ func Example__5() {
 	// nil	false
 }
 
-func Example__6() {
+func TestExample__6(t *testing.T) {
 	const code = `
 	local sorted = {}
 	for k, v in countries() do
@@ -252,7 +253,7 @@ func Example__6() {
 	L.SetGlobal("countries", New(L, countries))
 
 	if err := L.DoString(code); err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	// Output:
 	// Canada
@@ -260,7 +261,7 @@ func Example__6() {
 	// Japan
 }
 
-func Example__7() {
+func TestExample__7(t *testing.T) {
 	const code = `
 	fn("a", 1, 2, 3)
 	fn("b")
@@ -280,7 +281,7 @@ func Example__7() {
 	L.SetGlobal("fn", New(L, fn))
 
 	if err := L.DoString(code); err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	// Output:
 	// a
@@ -292,7 +293,7 @@ func Example__7() {
 	// 4
 }
 
-func Example__8() {
+func TestExample__8(t *testing.T) {
 	const code = `
 	for _, x in ipairs(fn(1, 2, 3)) do
 		print(x)
@@ -319,7 +320,7 @@ func Example__8() {
 	L.SetGlobal("fn", New(L, fn))
 
 	if err := L.DoString(code); err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	// Output:
 	// 3
@@ -328,7 +329,7 @@ func Example__8() {
 	// 4
 }
 
-func Example__9() {
+func TestExample__9(t *testing.T) {
 	const code = `
 	print(#items)
 	print(items:capacity())
@@ -347,7 +348,7 @@ func Example__9() {
 	L.SetGlobal("items", New(L, items))
 
 	if err := L.DoString(code); err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	// Output:
 	// 0
@@ -358,7 +359,7 @@ func Example__9() {
 	// world
 }
 
-func Example__10() {
+func TestExample__10(t *testing.T) {
 	const code = `
 	ints = newInts(1)
 	print(#ints, ints:capacity())
@@ -375,14 +376,14 @@ func Example__10() {
 	L.SetGlobal("newInts", NewType(L, ints{}))
 
 	if err := L.DoString(code); err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	// Output:
 	// 1	1
 	// 0	10
 }
 
-func Example__11() {
+func TestExample__11(t *testing.T) {
 	const code = `
 	print(-p1 == -p1)
 	print(-p1 == -p1_alias)
@@ -406,7 +407,7 @@ func Example__11() {
 	L.SetGlobal("p2", New(L, &p2))
 
 	if err := L.DoString(code); err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	// Output:
 	// true
@@ -416,7 +417,7 @@ func Example__11() {
 	// false
 }
 
-func Example__12() {
+func TestExample__12(t *testing.T) {
 	const code = `
 	print(p1)
 	print(p2)
@@ -438,14 +439,14 @@ func Example__12() {
 	L.SetGlobal("p2", New(L, &p2))
 
 	if err := L.DoString(code); err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	// Output:
 	// Tim (99)
 	// John (2)
 }
 
-func Example__13() {
+func TestExample__13(t *testing.T) {
 	const code = `
 	print(p:AddNumbers(1, 2, 3, 4, 5))
 	`
@@ -460,13 +461,13 @@ func Example__13() {
 	L.SetGlobal("p", New(L, &p))
 
 	if err := L.DoString(code); err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	// Output:
 	// Tim counts: 15
 }
 
-func Example__14() {
+func TestExample__14(t *testing.T) {
 	const code = `
 	print(p:hello())
 	print(p.age)
@@ -483,7 +484,7 @@ func Example__14() {
 	L.SetGlobal("p", New(L, &p))
 
 	if err := L.DoString(code); err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	// Output:
 	// Hello, Tim
@@ -496,7 +497,7 @@ func (o OneString) Print() {
 	fmt.Println(o[0])
 }
 
-func Example__15() {
+func TestExample__15(t *testing.T) {
 	const code = `
 	print(#e.V, e.V[1], e.V[2])
 	e.V[1] = "World"
@@ -525,7 +526,7 @@ func Example__15() {
 	L.SetGlobal("arr", New(L, arr))
 
 	if err := L.DoString(code); err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	// Output:
 	// 2	Hello	World
@@ -534,7 +535,7 @@ func Example__15() {
 	// Test
 }
 
-func Example__16() {
+func TestExample__16(t *testing.T) {
 	const code = `
 	print(fn("tim", 5))
 	`
@@ -553,13 +554,13 @@ func Example__16() {
 	L.SetGlobal("fn", New(L, fn))
 
 	if err := L.DoString(code); err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	// Output:
 	// tim	tim	tim	tim	tim
 }
 
-func Example__17() {
+func TestExample__17(t *testing.T) {
 	const code = `
 	print(-ptr)
 	`
@@ -572,13 +573,13 @@ func Example__17() {
 	L.SetGlobal("ptr", New(L, &str))
 
 	if err := L.DoString(code); err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	// Output:
 	// hello
 }
 
-func Example__18() {
+func TestExample__18(t *testing.T) {
 	const code = `
 	print(ptr1 == nil)
 	print(ptr2 == nil)
@@ -595,7 +596,7 @@ func Example__18() {
 	L.SetGlobal("ptr2", New(L, &str))
 
 	if err := L.DoString(code); err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	// Output:
 	// true
@@ -603,7 +604,7 @@ func Example__18() {
 	// false
 }
 
-func Example__19() {
+func TestExample__19(t *testing.T) {
 	const code = `
 	print(-str)
 	print(str ^ "world")
@@ -618,7 +619,7 @@ func Example__19() {
 	L.SetGlobal("str", New(L, &str))
 
 	if err := L.DoString(code); err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	// Output:
 	// hello
@@ -635,7 +636,7 @@ type Example__20_B struct {
 	Person
 }
 
-func Example__20() {
+func TestExample__20(t *testing.T) {
 	const code = `
 	print(a.Value == nil)
 	a.Value = str_ptr()
@@ -660,7 +661,7 @@ func Example__20() {
 	L.SetGlobal("str_ptr", NewType(L, ""))
 
 	if err := L.DoString(code); err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	// Output:
 	// true
@@ -669,7 +670,7 @@ func Example__20() {
 	// Tim
 }
 
-func Example__21() {
+func TestExample__21(t *testing.T) {
 	const code = `
 	print(fn == nil)
 	`
@@ -682,13 +683,13 @@ func Example__21() {
 	L.SetGlobal("fn", New(L, fn))
 
 	if err := L.DoString(code); err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	// Output:
 	// true
 }
 
-func Example__22() {
+func TestExample__22(t *testing.T) {
 	const code = `
 	fn(arr)
 	`
@@ -705,13 +706,13 @@ func Example__22() {
 	L.SetGlobal("arr", New(L, arr))
 
 	if err := L.DoString(code); err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	// Output:
 	// 1 2 3
 }
 
-func Example__23() {
+func TestExample__23(t *testing.T) {
 	const code = `
 	b = a
 	`
@@ -724,7 +725,7 @@ func Example__23() {
 	L.SetGlobal("a", New(L, a))
 
 	if err := L.DoString(code); err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	b := L.GetGlobal("b").(*lua.LUserData).Value.(complex128)
 	fmt.Println(a == b)
@@ -757,7 +758,7 @@ func (m MapAlias) Y() int {
 	return len(m)
 }
 
-func Example__24() {
+func TestExample__24(t *testing.T) {
 	const code = `
 	print(a:Test())
 	local len1 = b:Len()
@@ -780,7 +781,7 @@ func Example__24() {
 	L.SetGlobal("c", New(L, c))
 
 	if err := L.DoString(code); err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	// Output:
 	// I'm a "chan string" alias
@@ -799,7 +800,7 @@ type E25A struct {
 	B E25B
 }
 
-func Example__25() {
+func TestExample__25(t *testing.T) {
 	const code = `
 	a.b:Test()
 	`
@@ -811,7 +812,7 @@ func Example__25() {
 	L.SetGlobal("a", New(L, &a))
 
 	if err := L.DoString(code); err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	a.B.Test()
 	// Output:
@@ -826,7 +827,7 @@ type E26A struct {
 	Hidden bool `luar:"-"`
 }
 
-func Example__26() {
+func TestExample__26(t *testing.T) {
 	const code = `
 	print(a.name)
 	print(a.Name)
@@ -849,7 +850,7 @@ func Example__26() {
 	L.SetGlobal("a", New(L, a))
 
 	if err := L.DoString(code); err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	// Output:
 	// tim
@@ -860,7 +861,7 @@ func Example__26() {
 	// nil
 }
 
-func Example__27() {
+func TestExample__27(t *testing.T) {
 	const code = `
 	print(a.Name)
 	_ = a ^ -b
@@ -881,7 +882,7 @@ func Example__27() {
 	L.SetGlobal("b", New(L, b))
 
 	if err := L.DoString(code); err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	// Output:
 	// tim
@@ -898,7 +899,7 @@ func (E28_Chan) Test2() {
 	fmt.Println("E28_Chan.Test2")
 }
 
-func Example__28() {
+func TestExample__28(t *testing.T) {
 	const code = `
 	b:Test()
 	b:Test2()
@@ -916,7 +917,7 @@ func Example__28() {
 	L.SetGlobal("b", New(L, b))
 
 	if err := L.DoString(code); err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	// Output:
 	// E28_Chan.Test
@@ -931,7 +932,7 @@ type E29_A struct {
 	E29_String
 }
 
-func Example__29() {
+func TestExample__29(t *testing.T) {
 	const code = `
 	a.E29_String = "world"
 	`
@@ -946,7 +947,7 @@ func Example__29() {
 	L.SetGlobal("a", New(L, &a))
 
 	if err := L.DoString(code); err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	fmt.Println(a.E29_String)
 	// Output:
@@ -969,7 +970,7 @@ type E30_B struct {
 	*E30_A
 }
 
-func Example__30() {
+func TestExample__30(t *testing.T) {
 	const code = `
 	b:public()
 	b.E30_A:public()
@@ -1007,7 +1008,7 @@ func Example__30() {
 	L.SetGlobal("b", New(L, b))
 
 	if err := L.DoString(code); err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	// Output:
 	// You can call me
@@ -1018,7 +1019,7 @@ type E_31 struct {
 	S []string
 }
 
-func Example__31() {
+func TestExample__31(t *testing.T) {
 	const code = `
 	x.S = {"a", "b", "", 3, true, "c"}
 	`
@@ -1030,7 +1031,7 @@ func Example__31() {
 	L.SetGlobal("x", New(L, e))
 
 	if err := L.DoString(code); err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	for _, v := range e.S {
 		fmt.Println(v)
@@ -1048,7 +1049,7 @@ type E_32 struct {
 	S map[string]string
 }
 
-func Example__32() {
+func TestExample__32(t *testing.T) {
 	const code = `
 	x.S = {
 		33,
@@ -1066,7 +1067,7 @@ func Example__32() {
 	L.SetGlobal("x", New(L, e))
 
 	if err := L.DoString(code); err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 
 	fmt.Println(len(e.S))
@@ -1088,7 +1089,7 @@ type E_33 struct {
 	P2 Person `luar:"other"`
 }
 
-func Example__33() {
+func TestExample__33(t *testing.T) {
 	const code = `
 	x.Person = {
 		Name = "Bill",
@@ -1115,7 +1116,7 @@ func Example__33() {
 	L.SetGlobal("x", New(L, e))
 
 	if err := L.DoString(code); err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 
 	fmt.Println(e.Name)
@@ -1143,7 +1144,7 @@ type E_34 struct {
 	C int    `luar:"-"`
 }
 
-func Example__34() {
+func TestExample__34(t *testing.T) {
 	const code = `
 	_ = x ^ {
 		q = "Cat",
@@ -1163,7 +1164,7 @@ func Example__34() {
 	L.SetGlobal("x", New(L, e))
 
 	if err := L.DoString(code); err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 
 	fmt.Println(e.A)
@@ -1180,7 +1181,7 @@ type E_35 struct {
 	Fn2 func(a string, b ...int) string
 }
 
-func Example__35() {
+func TestExample__35(t *testing.T) {
 	const code = `
 	i = 0
 	x.Fn = function(str)
@@ -1203,7 +1204,7 @@ func Example__35() {
 	L.SetGlobal("x", New(L, e))
 
 	if err := L.DoString(code); err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 
 	for ch := 'A'; ch <= 'C'; ch++ {
@@ -1215,7 +1216,7 @@ func Example__35() {
 	fmt.Println(e.Fn2("hello", 1, 2, 3))
 
 	if L.GetTop() != 0 {
-		panic("expecting GetTop to return 0, got " + strconv.Itoa(L.GetTop()))
+		t.Fatal("expecting GetTop to return 0, got " + strconv.Itoa(L.GetTop()))
 	}
 	// Output:
 	// >A< 1
@@ -1229,7 +1230,7 @@ type E_36 struct {
 	F1 *lua.LFunction
 }
 
-func Example__36() {
+func TestExample__36(t *testing.T) {
 	const code = `
 	x.F1 = function(str)
 		print("Hello World")
@@ -1243,7 +1244,7 @@ func Example__36() {
 	L.SetGlobal("x", New(L, e))
 
 	if err := L.DoString(code); err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 
 	L.Push(e.F1)
@@ -1253,7 +1254,7 @@ func Example__36() {
 	// Hello World
 }
 
-func Example__37() {
+func TestExample__37(t *testing.T) {
 	const code = `
 	for i, x in s() do
 		print(i, x)
@@ -1288,7 +1289,7 @@ func Example__37() {
 	L.SetGlobal("ap", New(L, &a))
 
 	if err := L.DoString(code); err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 
 	// Output:
@@ -1307,7 +1308,7 @@ func (s *E38String) ToUpper() {
 	*s = E38String(strings.ToUpper(string(*s)))
 }
 
-func Example__38() {
+func TestExample__38(t *testing.T) {
 	const code = `
 	print(a[1]:AddNumbers(1, 2, 3, 4, 5))
 	print(s[1]:AddNumbers(1, 2, 3, 4))
@@ -1342,7 +1343,7 @@ func Example__38() {
 	L.SetGlobal("str", New(L, &str))
 
 	if err := L.DoString(code); err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 
 	// Output:
@@ -1357,7 +1358,7 @@ func Example__38() {
 	// HELLO WORLD
 }
 
-func ExampleLState() {
+func TestExampleLState(t *testing.T) {
 	const code = `
 	print(sum(1, 2, 3, 4, 5))
 	`
@@ -1377,13 +1378,13 @@ func ExampleLState() {
 	L.SetGlobal("sum", New(L, sum))
 
 	if err := L.DoString(code); err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	// Output:
 	// 15
 }
 
-func ExampleNewType() {
+func TestExampleNewType(t *testing.T) {
 	L := lua.NewState()
 	defer L.Close()
 
@@ -1401,4 +1402,315 @@ func ExampleNewType() {
 	`)
 	// Output:
 	// Tycho - Montana
+}
+
+func TestExample__Immutable1(t *testing.T) {
+	// Modifying a field on an immutable struct - should error
+	const code = `
+	p.Name = "Tom"
+	`
+
+	L := lua.NewState()
+	defer L.Close()
+
+	p := Person{
+		Name: "Tim",
+		Age:  66,
+	}
+
+	L.SetGlobal("p", NewWithOptions(L, p, ReflectOptions{Immutable: true}))
+
+	err := L.DoString(code)
+	if err == nil {
+		t.Fatal("Expected error, none thrown")
+	}
+	if !strings.Contains(err.Error(), "invalid operation on immutable struct") {
+		t.Fatal("Expected invalid operation error, got:", err)
+	}
+}
+
+func TestExample__Immutable2(t *testing.T) {
+	// Calling a pointer function on an immutable struct - should error
+	const code = `
+	p:IncreaseAge()
+	`
+
+	L := lua.NewState()
+	defer L.Close()
+
+	p := Person{
+		Name: "Tim",
+		Age:  66,
+	}
+
+	L.SetGlobal("p", NewWithOptions(L, &p, ReflectOptions{Immutable: true}))
+
+	err := L.DoString(code)
+	if err == nil {
+		t.Fatal("Expected error, none thrown")
+	}
+	if !strings.Contains(err.Error(), "attempt to call a non-function object") {
+		t.Fatal("Expected call error, got:", err)
+	}
+}
+
+func TestExample__Immutable3(t *testing.T) {
+	// Accessing a field and calling a regular function on an immutable
+	// struct - should be fine
+	const code = `
+	p:Hello()
+	print(p.Name)
+	`
+
+	L := lua.NewState()
+	defer L.Close()
+
+	p := Person{
+		Name: "Tim",
+		Age:  66,
+	}
+
+	L.SetGlobal("p", NewWithOptions(L, p, ReflectOptions{Immutable: true}))
+
+	if err := L.DoString(code); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestExample__Immutable4(t *testing.T) {
+	// Attempting to modify an immutable slice - should error
+	const code = `
+	s[1] = "hi"
+	`
+
+	L := lua.NewState()
+	defer L.Close()
+
+	s := []string{"first", "second"}
+	L.SetGlobal("s", NewWithOptions(L, s, ReflectOptions{Immutable: true}))
+
+	err := L.DoString(code)
+	if err == nil {
+		t.Fatal("Expected error, none thrown")
+	}
+	if !strings.Contains(err.Error(), "invalid operation on immutable slice") {
+		t.Fatal("Expected invalid operation error, got:", err)
+	}
+}
+
+func TestExample__Immutable5(t *testing.T) {
+	// Attempting to append to an immutable slice - should error
+	const code = `
+	s = s:append("hi")
+	`
+
+	L := lua.NewState()
+	defer L.Close()
+
+	s := []string{"first", "second"}
+	L.SetGlobal("s", NewWithOptions(L, s, ReflectOptions{Immutable: true}))
+
+	err := L.DoString(code)
+	if err == nil {
+		t.Fatal("Expected error, none thrown")
+	}
+	if !strings.Contains(err.Error(), "invalid operation on immutable slice") {
+		t.Fatal("Expected invalid operation error, got:", err)
+	}
+}
+
+func TestExample__Immutable6(t *testing.T) {
+	// Attempting to access a member of an immutable slice - should be fine
+	const code = `
+	print(s[1])
+	`
+
+	L := lua.NewState()
+	defer L.Close()
+
+	s := []string{"first", "second"}
+	L.SetGlobal("s", NewWithOptions(L, s, ReflectOptions{Immutable: true}))
+
+	if err := L.DoString(code); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestExample__Immutable7(t *testing.T) {
+	// Attempting to modify an immutable map - should error
+	const code = `
+	m["newKey"] = "hi"
+	`
+
+	L := lua.NewState()
+	defer L.Close()
+
+	m := map[string]string{"first": "foo", "second": "bar"}
+	L.SetGlobal("m", NewWithOptions(L, m, ReflectOptions{Immutable: true}))
+
+	err := L.DoString(code)
+	if err == nil {
+		t.Fatal("Expected error, none thrown")
+	}
+	if !strings.Contains(err.Error(), "invalid operation on immutable map") {
+		t.Fatal("Expected invalid operation error, got:", err)
+	}
+}
+
+func TestExample__Immutable8(t *testing.T) {
+	// Attempting to access a member of an immutable map - should be fine
+	const code = `
+	print(m["first"])
+	`
+
+	L := lua.NewState()
+	defer L.Close()
+
+	m := map[string]string{"first": "foo", "second": "bar"}
+	L.SetGlobal("m", NewWithOptions(L, m, ReflectOptions{Immutable: true}))
+
+	if err := L.DoString(code); err != nil {
+		t.Fatal(err)
+	}
+}
+
+type Family struct {
+	Mother Person
+	Father Person
+	Children []Person
+}
+
+func TestExample__Immutable9(t *testing.T) {
+	// Attempt to modify a nested field on an immutable struct - should error
+	const code = `
+	f.Mother.Name = "Laura"
+	`
+
+	L := lua.NewState()
+	defer L.Close()
+
+	f := Family{
+		Mother: Person{
+			Name: "Luara",
+		},
+		Father: Person{
+			Name: "Tim",
+		},
+	}
+
+	L.SetGlobal("f", NewWithOptions(L, f, ReflectOptions{Immutable: true}))
+
+	err := L.DoString(code)
+	if err == nil {
+		t.Fatal("Expected error, none thrown")
+	}
+	if !strings.Contains(err.Error(), "invalid operation on immutable struct") {
+		t.Fatal("Expected invalid operation error, got:", err)
+	}
+}
+
+func TestExample__Immutable10(t *testing.T) {
+	// Attempt to modify a nested field in a nested slice, on an immutable
+	// struct - should error
+	const code = `
+	f.Children[1].Name = "Bill"
+	`
+
+	L := lua.NewState()
+	defer L.Close()
+
+	f := Family{
+		Mother: Person{
+			Name: "Luara",
+		},
+		Father: Person{
+			Name: "Tim",
+		},
+		Children: []Person{
+			{ Name: "Bill" },
+		},
+	}
+
+	L.SetGlobal("f", NewWithOptions(L, f, ReflectOptions{Immutable: true}))
+
+	err := L.DoString(code)
+	if err == nil {
+		t.Fatal("Expected error, none thrown")
+	}
+	if !strings.Contains(err.Error(), "invalid operation on immutable struct") {
+		t.Fatal("Expected invalid operation error, got:", err)
+	}
+}
+
+func TestExample__Immutable11(t *testing.T) {
+	// Attempt to modify a nested field in a nested slice, on an immutable
+	// struct pointer - should error
+	const code = `
+	f.Children[1].Name = "Bill"
+	`
+
+	L := lua.NewState()
+	defer L.Close()
+
+	f := Family{
+		Mother: Person{
+			Name: "Luara",
+		},
+		Father: Person{
+			Name: "Tim",
+		},
+		Children: []Person{
+			{ Name: "Bill" },
+		},
+	}
+
+	L.SetGlobal("f", NewWithOptions(L, &f, ReflectOptions{Immutable: true}))
+
+	err := L.DoString(code)
+	if err == nil {
+		t.Fatal("Expected error, none thrown")
+	}
+	if !strings.Contains(err.Error(), "invalid operation on immutable struct") {
+		t.Fatal("Expected invalid operation error, got:", err)
+	}
+}
+
+func TestExample__Immutable12(t *testing.T) {
+	// Attempt to modify the value of an immutable pointer - should error
+	const code = `
+	_ = str ^ "world"
+	`
+
+	L := lua.NewState()
+	defer L.Close()
+
+	str := "hello"
+
+	L.SetGlobal("str", NewWithOptions(L, &str, ReflectOptions{Immutable: true}))
+
+	err := L.DoString(code)
+	if err == nil {
+		t.Fatal("Expected error, none thrown")
+	}
+	if !strings.Contains(err.Error(), "invalid operation for immutable pointer") {
+		t.Fatal("Expected invalid operation error, got:", err)
+	}
+}
+
+func TestExample__Immutable13(t *testing.T) {
+	// Attempt to access the value of an immutable pointer - should be fine
+	const code = `
+	print(-str)
+	`
+
+	L := lua.NewState()
+	defer L.Close()
+
+	str := "hello"
+
+	L.SetGlobal("str", NewWithOptions(L, &str, ReflectOptions{Immutable: true}))
+
+	if err := L.DoString(code); err != nil {
+		t.Fatal(err)
+	}
 }

--- a/luar.go
+++ b/luar.go
@@ -99,7 +99,8 @@ type ReflectOptions struct {
 	// For structs, will auto-populate and auto-indirect pointer fields. This
 	// makes structs with pointer fields behave like their non-pointer counterparts.
 	// Fields are populated with a zero-value object upon first access, and can
-	// have values assigned directly without use of the pow (^) operator.
+	// have values assigned directly without use of the pow (^) operator. Note
+	// that fields can only be set if the struct is reflected by reference.
 	TransparentPointers bool
 }
 

--- a/luar.go
+++ b/luar.go
@@ -38,7 +38,7 @@ import (
 //  String          LString          No
 //  Struct          *LUserData       Yes
 //  UnsafePointer   *LUserData       No
-func New(L *lua.LState, value interface{}, opts... ReflectOptions) lua.LValue {
+func New(L *lua.LState, value interface{}, opts ...ReflectOptions) lua.LValue {
 	var reflectOptions ReflectOptions
 	if len(opts) > 0 {
 		reflectOptions = opts[0]

--- a/map.go
+++ b/map.go
@@ -42,15 +42,21 @@ func mapIndex(L *lua.LState) int {
 
 		return 0
 	}
-	L.Push(New(L, item.Interface()))
+	L.Push(NewWithOptions(L, item.Interface(), mt.reflectOptions()))
 	return 1
 }
 
 func mapNewIndex(L *lua.LState) int {
-	ref, _, isPtr := check(L, 1, reflect.Map)
+	ref, mt, isPtr := check(L, 1, reflect.Map)
+
 	if isPtr {
 		L.RaiseError("invalid operation on map pointer")
 	}
+
+	if mt.immutable() {
+		L.RaiseError("invalid operation on immutable map")
+	}
+
 	key := L.CheckAny(2)
 	value := L.CheckAny(3)
 

--- a/map.go
+++ b/map.go
@@ -42,7 +42,7 @@ func mapIndex(L *lua.LState) int {
 
 		return 0
 	}
-	L.Push(NewWithOptions(L, item.Interface(), mt.reflectOptions()))
+	L.Push(New(L, item.Interface(), mt.reflectOptions()))
 	return 1
 }
 

--- a/metatable.go
+++ b/metatable.go
@@ -20,7 +20,7 @@ func MT(L *lua.LState, value interface{}) *Metatable {
 	switch val.Type().Kind() {
 	case reflect.Array, reflect.Chan, reflect.Map, reflect.Ptr, reflect.Slice, reflect.Struct:
 		return &Metatable{
-			LTable: getMetatableFromValue(L, val),
+			LTable: getMetatableFromValue(L, val, ReflectOptions{}),
 			l:      L,
 		}
 	default:
@@ -114,4 +114,28 @@ func (m *Metatable) fieldIndex(name string) []int {
 		return index.(*lua.LUserData).Value.([]int)
 	}
 	return nil
+}
+
+// Retrieval of reflection options.
+func (m *Metatable) immutable() bool {
+	val := m.RawGetString("immutable")
+	if val == lua.LTrue {
+		return true
+	}
+	return false
+}
+
+func (m *Metatable) transparentPointers() bool {
+	val := m.RawGetString("transparent_pointers")
+	if val == lua.LTrue {
+		return true
+	}
+	return false
+}
+
+func (m *Metatable) reflectOptions() ReflectOptions {
+	return ReflectOptions{
+		Immutable: m.immutable(),
+		TransparentPointers: m.transparentPointers(),
+	}
 }

--- a/metatable.go
+++ b/metatable.go
@@ -135,7 +135,7 @@ func (m *Metatable) transparentPointers() bool {
 
 func (m *Metatable) reflectOptions() ReflectOptions {
 	return ReflectOptions{
-		Immutable: m.immutable(),
+		Immutable:           m.immutable(),
 		TransparentPointers: m.transparentPointers(),
 	}
 }

--- a/ptr.go
+++ b/ptr.go
@@ -35,7 +35,12 @@ func ptrIndex(L *lua.LState) int {
 }
 
 func ptrPow(L *lua.LState) int {
-	ref, _ := checkPtr(L, 1)
+	ref, mt := checkPtr(L, 1)
+
+	if mt.immutable() {
+		L.RaiseError("invalid operation for immutable pointer")
+	}
+
 	val := L.CheckAny(2)
 
 	if ref.IsNil() {

--- a/slice.go
+++ b/slice.go
@@ -8,6 +8,7 @@ import (
 
 func sliceIndex(L *lua.LState) int {
 	ref, mt, isPtr := check(L, 1, reflect.Slice)
+	ref = reflect.Indirect(ref)
 	key := L.CheckAny(2)
 
 	switch converted := key.(type) {
@@ -20,7 +21,7 @@ func sliceIndex(L *lua.LState) int {
 		if (val.Kind() == reflect.Struct || val.Kind() == reflect.Array) && val.CanAddr() {
 			val = val.Addr()
 		}
-		L.Push(NewWithOptions(L, val.Interface(), mt.reflectOptions()))
+		L.Push(New(L, val.Interface(), mt.reflectOptions()))
 	case lua.LString:
 		if !isPtr {
 			if fn := mt.method(string(converted)); fn != nil {

--- a/slice.go
+++ b/slice.go
@@ -20,7 +20,7 @@ func sliceIndex(L *lua.LState) int {
 		if (val.Kind() == reflect.Struct || val.Kind() == reflect.Array) && val.CanAddr() {
 			val = val.Addr()
 		}
-		L.Push(New(L, val.Interface()))
+		L.Push(NewWithOptions(L, val.Interface(), mt.reflectOptions()))
 	case lua.LString:
 		if !isPtr {
 			if fn := mt.method(string(converted)); fn != nil {
@@ -40,12 +40,16 @@ func sliceIndex(L *lua.LState) int {
 }
 
 func sliceNewIndex(L *lua.LState) int {
-	ref, _, isPtr := check(L, 1, reflect.Slice)
+	ref, mt, isPtr := check(L, 1, reflect.Slice)
 	index := L.CheckInt(2)
 	value := L.CheckAny(3)
 
 	if isPtr {
 		L.RaiseError("invalid operation on slice pointer")
+	}
+
+	if mt.immutable() {
+		L.RaiseError("invalid operation on immutable slice")
 	}
 
 	if index < 1 || index > ref.Len() {
@@ -97,7 +101,15 @@ func sliceCapacity(L *lua.LState) int {
 }
 
 func sliceAppend(L *lua.LState) int {
-	ref, _, _ := check(L, 1, reflect.Slice)
+	ref, mt, isPtr := check(L, 1, reflect.Slice)
+
+	if isPtr {
+		L.RaiseError("invalid operation on slice pointer")
+	}
+
+	if mt.immutable() {
+		L.RaiseError("invalid operation on immutable slice")
+	}
 
 	hint := ref.Type().Elem()
 	values := make([]reflect.Value, L.GetTop()-1)

--- a/struct.go
+++ b/struct.go
@@ -32,24 +32,26 @@ func structIndex(L *lua.LState) int {
 		L.RaiseError("cannot interface field " + key)
 	}
 
-	switch field.Kind() {
-	case reflect.Ptr:
-		if mt.transparentPointers() {
-			// Initialize pointers on first access
-			if !field.IsValid() || field.IsNil() {
-				field.Set(reflect.New(field.Type().Elem()))
-			}
+	if field.CanSet() {
+		switch field.Kind() {
+		case reflect.Ptr:
+			if mt.transparentPointers() {
+				// Initialize pointers on first access
+				if !field.IsValid() || field.IsNil() {
+					field.Set(reflect.New(field.Type().Elem()))
+				}
 
-			// Return the value of the pointer
-			if field.Elem().IsValid() {
-				field = field.Elem()
+				// Return the value of the pointer
+				if field.Elem().IsValid() {
+					field = field.Elem()
+				}
 			}
-		}
-	case reflect.Slice:
-		if mt.transparentPointers() {
-			// Initialize slices on first access
-			if !field.IsValid() || field.IsNil() {
-				field.Set(reflect.MakeSlice(field.Type(), 0, 10))
+		case reflect.Slice:
+			if mt.transparentPointers() {
+				// Initialize slices on first access
+				if !field.IsValid() || field.IsNil() {
+					field.Set(reflect.MakeSlice(field.Type(), 0, 10))
+				}
 			}
 		}
 	}

--- a/struct.go
+++ b/struct.go
@@ -39,14 +39,13 @@ func structIndex(L *lua.LState) int {
 		}
 	case reflect.Ptr:
 		if mt.transparentPointers() {
-			// Initialize pointers on first access if they're a struct
+			// Initialize pointers on first access
 			if !field.IsValid() || field.IsNil() {
-				if field.Type().Elem().Kind() == reflect.Struct {
-					field.Set(reflect.New(field.Type().Elem()))
-				}
+				field.Set(reflect.New(field.Type().Elem()))
 			}
-			// Otherwise return the value of the pointer
-			if field.Elem().IsValid() && field.Elem().Type().Kind() != reflect.Struct {
+
+			// Return the value of the pointer
+			if field.Elem().IsValid() {
 				field = field.Elem()
 			}
 		}
@@ -63,7 +62,7 @@ func structIndex(L *lua.LState) int {
 		field = field.Addr()
 	}
 
-	L.Push(NewWithOptions(L, field.Interface(), mt.reflectOptions()))
+	L.Push(New(L, field.Interface(), mt.reflectOptions()))
 	return 1
 }
 

--- a/struct.go
+++ b/struct.go
@@ -91,6 +91,11 @@ func structNewIndex(L *lua.LState) int {
 			hint := field.Type().Elem()
 			goValue := lValueToReflect(L, value, hint, nil)
 
+			if !field.CanSet() {
+				// Can happen if the field is on a struct reflected by
+				// value instead of by reference.
+				L.RaiseError("cannot set field " + key)
+			}
 			field.Set(reflect.New(goValue.Type()))
 			field.Elem().Set(goValue)
 			return 0

--- a/struct.go
+++ b/struct.go
@@ -32,9 +32,39 @@ func structIndex(L *lua.LState) int {
 		L.RaiseError("cannot interface field " + key)
 	}
 
+	switch field.Kind() {
+	case reflect.Array, reflect.Struct:
+		if field.CanAddr() {
+			field = field.Addr()
+		}
+	case reflect.Ptr:
+		if mt.transparentPointers() {
+			// Initialize pointers on first access if they're a struct
+			if !field.IsValid() || field.IsNil() {
+				if field.Type().Elem().Kind() == reflect.Struct {
+					field.Set(reflect.New(field.Type().Elem()))
+				}
+			}
+			// Otherwise return the value of the pointer
+			if field.Elem().IsValid() && field.Elem().Type().Kind() != reflect.Struct {
+				field = field.Elem()
+			}
+		}
+	case reflect.Slice:
+		if mt.transparentPointers() {
+			// Initialize slices on first access
+			if !field.IsValid() || field.IsNil() {
+				field.Set(reflect.MakeSlice(field.Type(), 0, 10))
+			}
+		}
+	}
+
 	if (field.Kind() == reflect.Struct || field.Kind() == reflect.Array) && field.CanAddr() {
 		field = field.Addr()
 	}
+
+
+
 	L.Push(NewWithOptions(L, field.Interface(), mt.reflectOptions()))
 	return 1
 }
@@ -58,6 +88,24 @@ func structNewIndex(L *lua.LState) int {
 		L.RaiseError("unknown field " + key)
 	}
 	field := ref.FieldByIndex(index)
+
+	if mt.transparentPointers() {
+		hint := field.Type()
+		if field.Type().Kind() == reflect.Ptr {
+			hint = field.Type().Elem()
+		}
+
+		goValue := lValueToReflect(L, value, hint, nil)
+
+		// If we're setting a pointer from a plain value, then we need to put it into addressable memory and
+		// assign the pointer value instead
+		if field.Type().Kind() == reflect.Ptr && goValue.Type().Kind() != reflect.Ptr {
+			field.Set(reflect.New(goValue.Type()))
+			field.Elem().Set(goValue)
+			return 0
+		}
+	}
+
 	if !field.CanSet() {
 		L.RaiseError("cannot set field " + key)
 	}

--- a/struct.go
+++ b/struct.go
@@ -35,15 +35,21 @@ func structIndex(L *lua.LState) int {
 	if (field.Kind() == reflect.Struct || field.Kind() == reflect.Array) && field.CanAddr() {
 		field = field.Addr()
 	}
-	L.Push(New(L, field.Interface()))
+	L.Push(NewWithOptions(L, field.Interface(), mt.reflectOptions()))
 	return 1
 }
 
 func structNewIndex(L *lua.LState) int {
 	ref, mt, isPtr := check(L, 1, reflect.Struct)
+
+	if mt.immutable() {
+		L.RaiseError("invalid operation on immutable struct")
+	}
+
 	if isPtr {
 		ref = ref.Elem()
 	}
+
 	key := L.CheckString(2)
 	value := L.CheckAny(3)
 

--- a/struct.go
+++ b/struct.go
@@ -63,8 +63,6 @@ func structIndex(L *lua.LState) int {
 		field = field.Addr()
 	}
 
-
-
 	L.Push(NewWithOptions(L, field.Interface(), mt.reflectOptions()))
 	return 1
 }


### PR DESCRIPTION
Add a new struct ReflectOptions that can be optionally passed when using luar.New to alter the behavior of a reflected gopher-luar object.

The Immutable flag controls whether or not the value of the reflected object can be modified. It only works for a subset of types that utilize a custom metatable - arrays, channels, maps, pointers, slices and structs. Child elements/fields inherit the immutable property, even when assigned to new variables. Immutable channels cannot be closed, but can still send/receive.

The TransparentPointers flag will auto-populate and auto-indirect pointer fields for reflected structs. This makes structs with pointer fields behave like their non-pointer counterparts. Fields are populated with a zero-value object upon first access, and can have values assigned directly without use of the pow (^) operator. Note that fields can only be set if the struct is reflected by reference.
