### PR TITLE
Overhaul ReflectOption storage to use a custom LUserData wrapper instead of metatable

### DIFF
--- a/array.go
+++ b/array.go
@@ -7,7 +7,7 @@ import (
 )
 
 func arrayIndex(L *lua.LState) int {
-	ref, mt, isPtr := check(L, 1, reflect.Array)
+	ref, opts, mt, isPtr := check(L, 1, reflect.Array)
 	ref = reflect.Indirect(ref)
 	key := L.CheckAny(2)
 
@@ -21,7 +21,7 @@ func arrayIndex(L *lua.LState) int {
 		if (val.Kind() == reflect.Struct || val.Kind() == reflect.Array) && val.CanAddr() {
 			val = val.Addr()
 		}
-		L.Push(New(L, val.Interface(), mt.reflectOptions()))
+		L.Push(New(L, val.Interface(), opts))
 	case lua.LString:
 		if !isPtr {
 			if fn := mt.method(string(converted)); fn != nil {
@@ -41,13 +41,13 @@ func arrayIndex(L *lua.LState) int {
 }
 
 func arrayNewIndex(L *lua.LState) int {
-	ref, mt, isPtr := check(L, 1, reflect.Array)
+	ref, opts, _, isPtr := check(L, 1, reflect.Array)
 
 	if !isPtr {
 		L.RaiseError("invalid operation on array")
 	}
 
-	if mt.immutable() {
+	if opts.Immutable {
 		L.RaiseError("invalid operation on immutable array")
 	}
 
@@ -63,14 +63,14 @@ func arrayNewIndex(L *lua.LState) int {
 }
 
 func arrayLen(L *lua.LState) int {
-	ref, _, _ := check(L, 1, reflect.Array)
+	ref, _, _, _ := check(L, 1, reflect.Array)
 	ref = reflect.Indirect(ref)
 	L.Push(lua.LNumber(ref.Len()))
 	return 1
 }
 
 func arrayCall(L *lua.LState) int {
-	ref, _, _ := check(L, 1, reflect.Array)
+	ref, _, _, _ := check(L, 1, reflect.Array)
 	ref = reflect.Indirect(ref)
 
 	i := 0

--- a/cache.go
+++ b/cache.go
@@ -125,7 +125,7 @@ func addFields(L *lua.LState, vtype reflect.Type, tbl *lua.LTable) {
 	}
 }
 
-func getMetatable(L *lua.LState, vtype reflect.Type, opts ReflectOptions) *lua.LTable {
+func getMetatable(L *lua.LState, vtype reflect.Type) *lua.LTable {
 	cache := getMTCache(L)
 
 	if vtype.Kind() == reflect.Ptr {
@@ -182,11 +182,7 @@ func getMetatable(L *lua.LState, vtype reflect.Type, opts ReflectOptions) *lua.L
 		mt.RawSetString("__index", L.NewFunction(ptrIndex))
 	}
 
-	// Don't want to allow pointer methods for immutable objects, since they could
-	// mutate state internally
-	if !opts.Immutable {
-		addMethods(L, reflect.PtrTo(vtype), ptrMethods, true)
-	}
+	addMethods(L, reflect.PtrTo(vtype), ptrMethods, true)
 	mt.RawSetString("ptr_methods", ptrMethods)
 
 	addMethods(L, vtype, methods, false)
@@ -194,21 +190,13 @@ func getMetatable(L *lua.LState, vtype reflect.Type, opts ReflectOptions) *lua.L
 
 	mt.RawSetString("original", L.NewTable())
 
-	// Reflection options
-	if opts.Immutable {
-		mt.RawSetString("immutable", lua.LTrue)
-	}
-	if opts.TransparentPointers {
-		mt.RawSetString("transparent_pointers", lua.LTrue)
-	}
-
 	cache.regular[vtype] = mt
 	return mt
 }
 
-func getMetatableFromValue(L *lua.LState, value reflect.Value, opts ReflectOptions) *lua.LTable {
+func getMetatableFromValue(L *lua.LState, value reflect.Value) *lua.LTable {
 	vtype := value.Type()
-	return getMetatable(L, vtype, opts)
+	return getMetatable(L, vtype)
 }
 
 func getTypeMetatable(L *lua.LState, t reflect.Type) *lua.LTable {

--- a/chan.go
+++ b/chan.go
@@ -7,7 +7,7 @@ import (
 )
 
 func chanIndex(L *lua.LState) int {
-	_, mt, isPtr := check(L, 1, reflect.Chan)
+	_, _, mt, isPtr := check(L, 1, reflect.Chan)
 	key := L.CheckString(2)
 
 	if !isPtr {
@@ -26,7 +26,7 @@ func chanIndex(L *lua.LState) int {
 }
 
 func chanLen(L *lua.LState) int {
-	ref, _, isPtr := check(L, 1, reflect.Chan)
+	ref, _, _, isPtr := check(L, 1, reflect.Chan)
 	if isPtr {
 		L.RaiseError("invalid operation on chan pointer")
 	}
@@ -37,7 +37,7 @@ func chanLen(L *lua.LState) int {
 // chan methods
 
 func chanSend(L *lua.LState) int {
-	ref, _, _ := check(L, 1, reflect.Chan)
+	ref, _, _, _ := check(L, 1, reflect.Chan)
 	value := L.CheckAny(2)
 	convertedValue := lValueToReflect(L, value, ref.Type().Elem(), nil)
 	if convertedValue.Type() != ref.Type().Elem() {
@@ -48,7 +48,7 @@ func chanSend(L *lua.LState) int {
 }
 
 func chanReceive(L *lua.LState) int {
-	ref, _, _ := check(L, 1, reflect.Chan)
+	ref, _, _, _ := check(L, 1, reflect.Chan)
 
 	value, ok := ref.Recv()
 	if !ok {
@@ -62,9 +62,9 @@ func chanReceive(L *lua.LState) int {
 }
 
 func chanClose(L *lua.LState) int {
-	ref, mt, _ := check(L, 1, reflect.Chan)
+	ref, opts, _, _ := check(L, 1, reflect.Chan)
 
-	if mt.immutable() {
+	if opts.Immutable {
 		L.RaiseError("cannot close immutable channel")
 	}
 

--- a/example_test.go
+++ b/example_test.go
@@ -174,7 +174,7 @@ func ExampleStructConstructorAndMap() {
 		panic(err)
 	}
 
-	everyone := L.GetGlobal("everyone").(*lua.LUserData).Value.(*ReflectedInterface).Interface.(map[string]*Person)
+	everyone := L.GetGlobal("everyone").(*lua.LUserData).Value.(*reflectedInterface).Interface.(map[string]*Person)
 	fmt.Println(len(everyone))
 
 	// Output:
@@ -755,7 +755,7 @@ func ExampleComplex() {
 	if err := L.DoString(code); err != nil {
 		panic(err)
 	}
-	b := L.GetGlobal("b").(*lua.LUserData).Value.(*ReflectedInterface).Interface.(complex128)
+	b := L.GetGlobal("b").(*lua.LUserData).Value.(*reflectedInterface).Interface.(complex128)
 	fmt.Println(a == b)
 
 	// Output:

--- a/example_test.go
+++ b/example_test.go
@@ -174,7 +174,7 @@ func ExampleStructConstructorAndMap() {
 		panic(err)
 	}
 
-	everyone := L.GetGlobal("everyone").(*lua.LUserData).Value.(map[string]*Person)
+	everyone := L.GetGlobal("everyone").(*lua.LUserData).Value.(*ReflectedInterface).Interface.(map[string]*Person)
 	fmt.Println(len(everyone))
 
 	// Output:
@@ -755,7 +755,7 @@ func ExampleComplex() {
 	if err := L.DoString(code); err != nil {
 		panic(err)
 	}
-	b := L.GetGlobal("b").(*lua.LUserData).Value.(complex128)
+	b := L.GetGlobal("b").(*lua.LUserData).Value.(*ReflectedInterface).Interface.(complex128)
 	fmt.Println(a == b)
 
 	// Output:
@@ -1366,7 +1366,7 @@ func ExampleStructArrayAndSlice() {
 	print(-str)
 	`
 
-	L := lua.NewState()
+	L := lua.NewState(lua.Options{IncludeGoStackTrace: true})
 	defer L.Close()
 
 	a := [...]Person{
@@ -1492,7 +1492,7 @@ func TestImmutableStructPtrFunc(t *testing.T) {
 	if err == nil {
 		t.Fatal("Expected error, none thrown")
 	}
-	if !strings.Contains(err.Error(), "attempt to call a non-function object") {
+	if !strings.Contains(err.Error(), "cannot call pointer methods on immutable objects") {
 		t.Fatal("Expected call error, got:", err)
 	}
 }

--- a/example_test.go
+++ b/example_test.go
@@ -1366,7 +1366,7 @@ func ExampleStructArrayAndSlice() {
 	print(-str)
 	`
 
-	L := lua.NewState(lua.Options{IncludeGoStackTrace: true})
+	L := lua.NewState()
 	defer L.Close()
 
 	a := [...]Person{

--- a/luar.go
+++ b/luar.go
@@ -70,20 +70,20 @@ func New(L *lua.LState, value interface{}, opts ...ReflectOptions) lua.LValue {
 		return lua.LNumber(val.Float())
 	case reflect.Array, reflect.Chan, reflect.Map, reflect.Ptr, reflect.Slice, reflect.Struct:
 		ud := L.NewUserData()
-		ud.Value = NewReflectedInterface(val.Interface(), reflectOptions)
+		ud.Value = newReflectedInterface(val.Interface(), reflectOptions)
 		ud.Metatable = getMetatableFromValue(L, val)
 		return ud
 	case reflect.Func:
 		return funcWrapper(L, val, false)
 	case reflect.Interface:
 		ud := L.NewUserData()
-		ud.Value = NewReflectedInterface(val.Interface(), reflectOptions)
+		ud.Value = newReflectedInterface(val.Interface(), reflectOptions)
 		return ud
 	case reflect.String:
 		return lua.LString(val.String())
 	default:
 		ud := L.NewUserData()
-		ud.Value = NewReflectedInterface(val.Interface(), reflectOptions)
+		ud.Value = newReflectedInterface(val.Interface(), reflectOptions)
 		return ud
 	}
 }
@@ -108,21 +108,20 @@ type ReflectOptions struct {
 // Default options if no ReflectOptions struct is passed into luar.New().
 func defaultReflectOptions() ReflectOptions {
 	return ReflectOptions{
-		Immutable: false,
+		Immutable:           false,
 		TransparentPointers: false,
 	}
 }
 
 // ReflectedInterface stores the reflected value for certain types requiring LUserData
 // storage - arrays, channels, maps, pointers, slices, structs. It holds both the value,and additional metadata.
-type ReflectedInterface struct {
+type reflectedInterface struct {
 	Interface interface{}
 	Options   ReflectOptions
 }
 
-
-func NewReflectedInterface(iface interface{}, opts ReflectOptions) *ReflectedInterface {
-	return &ReflectedInterface{Interface: iface, Options: opts}
+func newReflectedInterface(iface interface{}, opts ReflectOptions) *reflectedInterface {
+	return &reflectedInterface{Interface: iface, Options: opts}
 }
 
 // NewType returns a new type creator for the given value's type.
@@ -289,7 +288,7 @@ func lValueToReflect(L *lua.LState, v lua.LValue, hint reflect.Type, tryConvertP
 		}
 	case *lua.LUserData:
 		var val reflect.Value
-		if refIface, ok := converted.Value.(*ReflectedInterface); ok {
+		if refIface, ok := converted.Value.(*reflectedInterface); ok {
 			val = reflect.ValueOf(refIface.Interface)
 		} else {
 			val = reflect.ValueOf(converted.Value)

--- a/map.go
+++ b/map.go
@@ -7,7 +7,7 @@ import (
 )
 
 func mapIndex(L *lua.LState) int {
-	ref, mt, isPtr := check(L, 1, reflect.Map)
+	ref, opts, mt, isPtr := check(L, 1, reflect.Map)
 	key := L.CheckAny(2)
 
 	if isPtr {
@@ -42,18 +42,18 @@ func mapIndex(L *lua.LState) int {
 
 		return 0
 	}
-	L.Push(New(L, item.Interface(), mt.reflectOptions()))
+	L.Push(New(L, item.Interface(), opts))
 	return 1
 }
 
 func mapNewIndex(L *lua.LState) int {
-	ref, mt, isPtr := check(L, 1, reflect.Map)
+	ref, opts, _, isPtr := check(L, 1, reflect.Map)
 
 	if isPtr {
 		L.RaiseError("invalid operation on map pointer")
 	}
 
-	if mt.immutable() {
+	if opts.Immutable {
 		L.RaiseError("invalid operation on immutable map")
 	}
 
@@ -76,7 +76,7 @@ func mapNewIndex(L *lua.LState) int {
 }
 
 func mapLen(L *lua.LState) int {
-	ref, _, isPtr := check(L, 1, reflect.Map)
+	ref, _, _, isPtr := check(L, 1, reflect.Map)
 	if isPtr {
 		L.RaiseError("invalid operation on map pointer")
 	}
@@ -85,7 +85,7 @@ func mapLen(L *lua.LState) int {
 }
 
 func mapCall(L *lua.LState) int {
-	ref, _, isPtr := check(L, 1, reflect.Map)
+	ref, _, _, isPtr := check(L, 1, reflect.Map)
 	if isPtr {
 		L.RaiseError("invalid operation on map pointer")
 	}

--- a/metatable.go
+++ b/metatable.go
@@ -20,7 +20,7 @@ func MT(L *lua.LState, value interface{}) *Metatable {
 	switch val.Type().Kind() {
 	case reflect.Array, reflect.Chan, reflect.Map, reflect.Ptr, reflect.Slice, reflect.Struct:
 		return &Metatable{
-			LTable: getMetatableFromValue(L, val, ReflectOptions{}),
+			LTable: getMetatableFromValue(L, val),
 			l:      L,
 		}
 	default:
@@ -114,28 +114,4 @@ func (m *Metatable) fieldIndex(name string) []int {
 		return index.(*lua.LUserData).Value.([]int)
 	}
 	return nil
-}
-
-// Retrieval of reflection options.
-func (m *Metatable) immutable() bool {
-	val := m.RawGetString("immutable")
-	if val == lua.LTrue {
-		return true
-	}
-	return false
-}
-
-func (m *Metatable) transparentPointers() bool {
-	val := m.RawGetString("transparent_pointers")
-	if val == lua.LTrue {
-		return true
-	}
-	return false
-}
-
-func (m *Metatable) reflectOptions() ReflectOptions {
-	return ReflectOptions{
-		Immutable:           m.immutable(),
-		TransparentPointers: m.transparentPointers(),
-	}
 }

--- a/ptr.go
+++ b/ptr.go
@@ -8,7 +8,7 @@ import (
 
 func checkPtr(L *lua.LState, idx int) (ref reflect.Value, opts ReflectOptions, mt *Metatable) {
 	ud := L.CheckUserData(idx)
-	refIface, ok := ud.Value.(*ReflectedInterface)
+	refIface, ok := ud.Value.(*reflectedInterface)
 	if !ok {
 		L.RaiseError("unexpected userdata value")
 	}
@@ -23,24 +23,6 @@ func checkPtr(L *lua.LState, idx int) (ref reflect.Value, opts ReflectOptions, m
 	mt = &Metatable{LTable: ud.Metatable.(*lua.LTable)}
 	return
 }
-
-//func checkPtr(L *lua.LState, idx int) (ref reflect.Value, opts ReflectOptions, mt *Metatable) {
-//	ud := L.CheckUserData(idx)
-//
-//	if refIface, ok := ud.Value.(*ReflectedInterface); ok {
-//		ref = reflect.ValueOf(refIface.Interface)
-//		opts = refIface.Options
-//	} else {
-//		ref = reflect.ValueOf(ud.Value)
-//	}
-//
-//	kind := reflect.Ptr
-//	if ref.Kind() != kind {
-//		L.ArgError(idx, "expecting "+kind.String())
-//	}
-//	mt = &Metatable{LTable: ud.Metatable.(*lua.LTable)}
-//	return
-//}
 
 func ptrIndex(L *lua.LState) int {
 	_, _, mt := checkPtr(L, 1)

--- a/ptr.go
+++ b/ptr.go
@@ -6,9 +6,16 @@ import (
 	"github.com/yuin/gopher-lua"
 )
 
-func checkPtr(L *lua.LState, idx int) (ref reflect.Value, mt *Metatable) {
+func checkPtr(L *lua.LState, idx int) (ref reflect.Value, opts ReflectOptions, mt *Metatable) {
 	ud := L.CheckUserData(idx)
-	ref = reflect.ValueOf(ud.Value)
+	refIface, ok := ud.Value.(*ReflectedInterface)
+	if !ok {
+		L.RaiseError("unexpected userdata value")
+	}
+
+	ref = reflect.ValueOf(refIface.Interface)
+	opts = refIface.Options
+
 	kind := reflect.Ptr
 	if ref.Kind() != kind {
 		L.ArgError(idx, "expecting "+kind.String())
@@ -17,8 +24,26 @@ func checkPtr(L *lua.LState, idx int) (ref reflect.Value, mt *Metatable) {
 	return
 }
 
+//func checkPtr(L *lua.LState, idx int) (ref reflect.Value, opts ReflectOptions, mt *Metatable) {
+//	ud := L.CheckUserData(idx)
+//
+//	if refIface, ok := ud.Value.(*ReflectedInterface); ok {
+//		ref = reflect.ValueOf(refIface.Interface)
+//		opts = refIface.Options
+//	} else {
+//		ref = reflect.ValueOf(ud.Value)
+//	}
+//
+//	kind := reflect.Ptr
+//	if ref.Kind() != kind {
+//		L.ArgError(idx, "expecting "+kind.String())
+//	}
+//	mt = &Metatable{LTable: ud.Metatable.(*lua.LTable)}
+//	return
+//}
+
 func ptrIndex(L *lua.LState) int {
-	_, mt := checkPtr(L, 1)
+	_, _, mt := checkPtr(L, 1)
 	key := L.CheckString(2)
 
 	if fn := mt.ptrMethod(key); fn != nil {
@@ -35,9 +60,9 @@ func ptrIndex(L *lua.LState) int {
 }
 
 func ptrPow(L *lua.LState) int {
-	ref, mt := checkPtr(L, 1)
+	ref, opts, _ := checkPtr(L, 1)
 
-	if mt.immutable() {
+	if opts.Immutable {
 		L.RaiseError("invalid operation for immutable pointer")
 	}
 
@@ -56,7 +81,7 @@ func ptrPow(L *lua.LState) int {
 }
 
 func ptrUnm(L *lua.LState) int {
-	ref, _ := checkPtr(L, 1)
+	ref, _, _ := checkPtr(L, 1)
 	elem := ref.Elem()
 	if !elem.CanInterface() {
 		L.RaiseError("cannot interface pointer type " + elem.String())

--- a/slice.go
+++ b/slice.go
@@ -7,7 +7,7 @@ import (
 )
 
 func sliceIndex(L *lua.LState) int {
-	ref, mt, isPtr := check(L, 1, reflect.Slice)
+	ref, opts, mt, isPtr := check(L, 1, reflect.Slice)
 	ref = reflect.Indirect(ref)
 	key := L.CheckAny(2)
 
@@ -21,7 +21,7 @@ func sliceIndex(L *lua.LState) int {
 		if (val.Kind() == reflect.Struct || val.Kind() == reflect.Array) && val.CanAddr() {
 			val = val.Addr()
 		}
-		L.Push(New(L, val.Interface(), mt.reflectOptions()))
+		L.Push(New(L, val.Interface(), opts))
 	case lua.LString:
 		if !isPtr {
 			if fn := mt.method(string(converted)); fn != nil {
@@ -41,7 +41,7 @@ func sliceIndex(L *lua.LState) int {
 }
 
 func sliceNewIndex(L *lua.LState) int {
-	ref, mt, isPtr := check(L, 1, reflect.Slice)
+	ref, opts, _, isPtr := check(L, 1, reflect.Slice)
 	index := L.CheckInt(2)
 	value := L.CheckAny(3)
 
@@ -49,7 +49,7 @@ func sliceNewIndex(L *lua.LState) int {
 		L.RaiseError("invalid operation on slice pointer")
 	}
 
-	if mt.immutable() {
+	if opts.Immutable {
 		L.RaiseError("invalid operation on immutable slice")
 	}
 
@@ -61,7 +61,7 @@ func sliceNewIndex(L *lua.LState) int {
 }
 
 func sliceLen(L *lua.LState) int {
-	ref, _, isPtr := check(L, 1, reflect.Slice)
+	ref, _, _, isPtr := check(L, 1, reflect.Slice)
 
 	if isPtr {
 		L.RaiseError("invalid operation on slice pointer")
@@ -72,7 +72,7 @@ func sliceLen(L *lua.LState) int {
 }
 
 func sliceCall(L *lua.LState) int {
-	ref, _, isPtr := check(L, 1, reflect.Slice)
+	ref, _, _, isPtr := check(L, 1, reflect.Slice)
 	if isPtr {
 		L.RaiseError("invalid operation on slice pointer")
 	}
@@ -96,19 +96,19 @@ func sliceCall(L *lua.LState) int {
 // slice methods
 
 func sliceCapacity(L *lua.LState) int {
-	ref, _, _ := check(L, 1, reflect.Slice)
+	ref, _, _, _ := check(L, 1, reflect.Slice)
 	L.Push(lua.LNumber(ref.Cap()))
 	return 1
 }
 
 func sliceAppend(L *lua.LState) int {
-	ref, mt, isPtr := check(L, 1, reflect.Slice)
+	ref, opts, _, isPtr := check(L, 1, reflect.Slice)
 
 	if isPtr {
 		L.RaiseError("invalid operation on slice pointer")
 	}
 
-	if mt.immutable() {
+	if opts.Immutable {
 		L.RaiseError("invalid operation on immutable slice")
 	}
 

--- a/util.go
+++ b/util.go
@@ -11,7 +11,7 @@ import (
 
 func check(L *lua.LState, idx int, kind reflect.Kind) (ref reflect.Value, opts ReflectOptions, mt *Metatable, isPtr bool) {
 	ud := L.CheckUserData(idx)
-	refIface, ok := ud.Value.(*ReflectedInterface)
+	refIface, ok := ud.Value.(*reflectedInterface)
 	if ok {
 		ref = reflect.ValueOf(refIface.Interface)
 		opts = refIface.Options
@@ -33,7 +33,7 @@ func check(L *lua.LState, idx int, kind reflect.Kind) (ref reflect.Value, opts R
 func tostring(L *lua.LState) int {
 	ud := L.CheckUserData(1)
 	value := ud.Value
-	if refIface, ok := value.(*ReflectedInterface); ok {
+	if refIface, ok := value.(*reflectedInterface); ok {
 		value = refIface.Interface
 	}
 	if stringer, ok := value.(fmt.Stringer); ok {


### PR DESCRIPTION
I was previously storing ReflectOptions flag on metatables, but this is invalid, since one metatable is shared across all objects that have the same kind. Thus, if one reflected a struct with `Immutable: true`, then all subsequent structs would use that option, regardless of what they actually specified. See `ExampleMultipleReflectedStructsDifferentOptions` for a test case exercising this scenario.

The new approach is to add a new wrapper type `reflectedInterface` that captures both the interface value, _and_ the ReflectOptions struct. This wrapper is then saved into the corresponding LUserData object.
