### PR TITLE
Pass down reflect options to more child objects

### DIFF
--- a/array.go
+++ b/array.go
@@ -70,7 +70,7 @@ func arrayLen(L *lua.LState) int {
 }
 
 func arrayCall(L *lua.LState) int {
-	ref, _, _, _ := check(L, 1, reflect.Array)
+	ref, opts, _, _ := check(L, 1, reflect.Array)
 	ref = reflect.Indirect(ref)
 
 	i := 0
@@ -80,7 +80,7 @@ func arrayCall(L *lua.LState) int {
 		}
 		item := ref.Index(i).Interface()
 		L.Push(lua.LNumber(i + 1))
-		L.Push(New(L, item))
+		L.Push(New(L, item, opts))
 		i++
 		return 2
 	}

--- a/example_test.go
+++ b/example_test.go
@@ -2216,3 +2216,34 @@ func ExampleMultipleReflectedStructsDifferentOptions() {
 	// world
 	// hello
 }
+
+func ExampleTransparentPtrSliceCall() {
+	// Iterate over a slice via the call method. Access an undefined pointer
+	// field on the returned object. Returned object should inherit the transparent
+	// pointer behavior, and the field should be accessible without indirection.
+	const code = `
+	for i, b in slice() do
+		print(i)
+		print(b.Str)
+	end
+	`
+
+	L := lua.NewState()
+	defer L.Close()
+
+	val := "foo"
+	b := TransparentPtrAccessB{}
+	b.Str = &val
+
+	slice := []*TransparentPtrAccessB{&b}
+
+	L.SetGlobal("slice", New(L, slice, ReflectOptions{TransparentPointers: true}))
+
+	if err := L.DoString(code); err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// 1
+	// foo
+}

--- a/map.go
+++ b/map.go
@@ -85,7 +85,7 @@ func mapLen(L *lua.LState) int {
 }
 
 func mapCall(L *lua.LState) int {
-	ref, _, _, isPtr := check(L, 1, reflect.Map)
+	ref, opts, _, isPtr := check(L, 1, reflect.Map)
 	if isPtr {
 		L.RaiseError("invalid operation on map pointer")
 	}
@@ -95,8 +95,8 @@ func mapCall(L *lua.LState) int {
 		if i >= len(keys) {
 			return 0
 		}
-		L.Push(New(L, keys[i].Interface()))
-		L.Push(New(L, ref.MapIndex(keys[i]).Interface()))
+		L.Push(New(L, keys[i].Interface(), opts))
+		L.Push(New(L, ref.MapIndex(keys[i]).Interface(), opts))
 		i++
 		return 2
 	}

--- a/ptr.go
+++ b/ptr.go
@@ -63,11 +63,11 @@ func ptrPow(L *lua.LState) int {
 }
 
 func ptrUnm(L *lua.LState) int {
-	ref, _, _ := checkPtr(L, 1)
+	ref, opts, _ := checkPtr(L, 1)
 	elem := ref.Elem()
 	if !elem.CanInterface() {
 		L.RaiseError("cannot interface pointer type " + elem.String())
 	}
-	L.Push(New(L, elem.Interface()))
+	L.Push(New(L, elem.Interface(), opts))
 	return 1
 }

--- a/slice.go
+++ b/slice.go
@@ -72,7 +72,7 @@ func sliceLen(L *lua.LState) int {
 }
 
 func sliceCall(L *lua.LState) int {
-	ref, _, _, isPtr := check(L, 1, reflect.Slice)
+	ref, opts, _, isPtr := check(L, 1, reflect.Slice)
 	if isPtr {
 		L.RaiseError("invalid operation on slice pointer")
 	}
@@ -84,7 +84,7 @@ func sliceCall(L *lua.LState) int {
 		}
 		item := ref.Index(i).Interface()
 		L.Push(lua.LNumber(i + 1))
-		L.Push(New(L, item))
+		L.Push(New(L, item, opts))
 		i++
 		return 2
 	}
@@ -123,6 +123,6 @@ func sliceAppend(L *lua.LState) int {
 	}
 
 	newSlice := reflect.Append(ref, values...)
-	L.Push(New(L, newSlice.Interface()))
+	L.Push(New(L, newSlice.Interface(), opts))
 	return 1
 }


### PR DESCRIPTION
Some methods on transparent ptr and immutable objects were not passing those reflection options down to the child objects. This should resolve these cases.