### PR TITLE
Allow ReflectOptions for functions, and apply to result objects

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -47,7 +47,7 @@ func addMethods(L *lua.LState, vtype reflect.Type, tbl *lua.LTable, ptrReceiver 
 		if method.PkgPath != "" {
 			continue
 		}
-		fn := funcWrapper(L, method.Func, ptrReceiver)
+		fn := funcWrapper(L, method.Func, ptrReceiver, defaultReflectOptions())
 		tbl.RawSetString(method.Name, fn)
 		tbl.RawSetString(getUnexportedName(method.Name), fn)
 	}

--- a/example_test.go
+++ b/example_test.go
@@ -1817,6 +1817,37 @@ func TestImmutableChanClose(t *testing.T) {
 	}
 }
 
+func TestImmutableFuncResult(t *testing.T) {
+	// When using reflect options on a function, those options should be applied
+	// to output values from the function. In this case, the output should have
+	// immutable behavior.
+
+	const code = `
+	person = getPerson()
+
+	-- person should have immutable behavior
+	person.Name = "Bob"
+	`
+
+	L := lua.NewState()
+	defer L.Close()
+
+	getPerson := func() *Person {
+		return &Person{Name: "Tim"}
+	}
+
+	L.SetGlobal("getPerson", New(L, getPerson, ReflectOptions{Immutable: true}))
+
+	err := L.DoString(code)
+	if err == nil {
+		t.Fatal("Expected error, none thrown")
+	}
+	if !strings.Contains(err.Error(), "invalid operation on immutable struct") {
+		t.Fatal("Expected invalid operation error, got:", err)
+	}
+}
+
+
 type TransparentPtrAccessB struct {
 	Str *string
 }
@@ -2246,4 +2277,34 @@ func ExampleTransparentPtrSliceCall() {
 	// Output:
 	// 1
 	// foo
+}
+
+func ExampleTransparentPtrFuncResult() {
+	// When using reflect options on a function, those options should be applied
+	// to output values from the function. In this case, the output should have
+	// transparent pointer behavior.
+
+	const code = `
+	b = newB()
+
+	-- b should have transparent ptr behavior
+	print(b.Str)
+	`
+
+	L := lua.NewState()
+	defer L.Close()
+
+	val := "hello"
+	newB := func() *TransparentPtrAccessB {
+		return &TransparentPtrAccessB{Str: &val}
+	}
+
+	L.SetGlobal("newB", New(L, newB, ReflectOptions{TransparentPointers: true}))
+
+	if err := L.DoString(code); err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// hello
 }

--- a/luar.go
+++ b/luar.go
@@ -74,7 +74,7 @@ func New(L *lua.LState, value interface{}, opts ...ReflectOptions) lua.LValue {
 		ud.Metatable = getMetatableFromValue(L, val)
 		return ud
 	case reflect.Func:
-		return funcWrapper(L, val, false)
+		return funcWrapper(L, val, false, reflectOptions)
 	case reflect.Interface:
 		ud := L.NewUserData()
 		ud.Value = newReflectedInterface(val.Interface(), reflectOptions)


### PR DESCRIPTION
Return values of the function will inherit the function's options.