### PR TITLE
Fixed bug with immutable and transparent pointers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,19 @@
 
 custom type reflection for [gopher-lua](https://github.com/yuin/gopher-lua).
 
+## oscarhealth fork
+
+This fork includes additional features targeted at modifying the behavior of reflected objects. In particular,
+the following are supported:
+
+* **Immutability**: Various types can be reflected as immutable, preventing any modification in Lua. This includes
+modification of struct fields, slices, maps, pointers, etc. A channel is prevented from being closed.
+* **Transparent pointers**: Objects can be reflected as if all pointer fields were plain value fields - automatically
+populating zero values as fields are accessed, and removing the need for the `^` and `-` operators that gopher-luar
+typically requires for manipulating pointers.
+
+See the documentation for usage.
+
 ## License
 
 MPL 2.0

--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@ the following are supported:
 
 * **Immutability**: Various types can be reflected as immutable, preventing any modification in Lua. This includes
 modification of struct fields, slices, maps, pointers, etc. A channel is prevented from being closed.
-* **Transparent pointers**: Objects can be reflected as if all pointer fields were plain value fields - automatically
-populating zero values as fields are accessed, and removing the need for the `^` and `-` operators that gopher-luar
-typically requires for manipulating pointers.
+* **Transparent pointers**: Objects can be reflected as if all pointer fields were plain value fields - removing
+  the need for the `^` and `-` operators that gopher-luar typically requires for manipulating pointers.
+* **Automatic population** On top of transparent pointers, objects can optionally have fields auto-created as they
+  are read from or written to. This removes the need to create those go types in lua, which can be messy.
 
 See the documentation for usage.
 

--- a/array.go
+++ b/array.go
@@ -70,7 +70,7 @@ func arrayLen(L *lua.LState) int {
 }
 
 func arrayCall(L *lua.LState) int {
-	ref, _, _, _ := check(L, 1, reflect.Array)
+	ref, opts, _, _ := check(L, 1, reflect.Array)
 	ref = reflect.Indirect(ref)
 
 	i := 0
@@ -80,7 +80,7 @@ func arrayCall(L *lua.LState) int {
 		}
 		item := ref.Index(i).Interface()
 		L.Push(lua.LNumber(i + 1))
-		L.Push(New(L, item))
+		L.Push(New(L, item, opts))
 		i++
 		return 2
 	}

--- a/cache.go
+++ b/cache.go
@@ -47,7 +47,7 @@ func addMethods(L *lua.LState, vtype reflect.Type, tbl *lua.LTable, ptrReceiver 
 		if method.PkgPath != "" {
 			continue
 		}
-		fn := funcWrapper(L, method.Func, ptrReceiver)
+		fn := funcWrapper(L, method.Func, ptrReceiver, defaultReflectOptions())
 		tbl.RawSetString(method.Name, fn)
 		tbl.RawSetString(getUnexportedName(method.Name), fn)
 	}

--- a/doc.go
+++ b/doc.go
@@ -193,9 +193,10 @@
 //  print(tim.Name) -- prints "Tim"; note that no dereference via - is req'd
 //  tim.Name = "Timothy" -- assignment works transparently too
 //
-// Note that this also takes care of populating zero values when pointers are
-// first accessed. This is to mimic the behavior of zero values on non-pointer
-// fields. Objects behave as if all fields are regular values.
+// Additionally, automatic population can be enabled; this takes care of
+// populating zero values when pointers are first accessed. This is to mimic
+// the behavior of zero values on non-pointer fields. Objects behave as if all
+// fields are regular values.
 //
 // Example:
 //  type Parent struct {
@@ -204,6 +205,8 @@
 //  }
 //  // No initialization of Name:
 //  tim := &Parent{}
+//  L.SetGlobal("tim", New(L, tim, ReflectOptions{
+//     TransparentPointers: true, AutoPopulate: true}))
 //  ---
 //  -- prints an empty string; does not raise an error, even though Child and
 //  -- Name are both nil when accessed
@@ -211,7 +214,7 @@
 //  -- afterwards, tim.Child will be set to a Person object, with a pointer to
 //  -- an empty string in Name
 //
-// This behavior is inherited by objects that are accessed through the
+// Any behavior is inherited by objects that are accessed through the
 // original reflected item. For example, functions reflected with
 // TransparentPointers will return objects that transparently dereference.
 //

--- a/example_test.go
+++ b/example_test.go
@@ -2051,7 +2051,7 @@ func TestTransparentValueAccess(t *testing.T) {
 	}
 }
 
-func ExampleTransparentNestedStructPtrAccess() {
+func ExampleAutoPopulateNestedStructs() {
 	// Access an undefined nested pointer field - should auto populate
 	// with zero values as if a non-pointer object
 	const code = `
@@ -2063,17 +2063,19 @@ func ExampleTransparentNestedStructPtrAccess() {
 
 	a := TransparentPtrAccessA{}
 
-	L.SetGlobal("a", New(L, &a, ReflectOptions{TransparentPointers: true}))
+	L.SetGlobal("a", New(L, &a, ReflectOptions{
+		TransparentPointers: true, AutoPopulate: true}))
 
 	if err := L.DoString(code); err != nil {
 		panic(err)
 	}
+	fmt.Println(*a.B.Str)
 
 	// Output:
 	//
 }
 
-func ExampleTransparentNestedStructPtrAssignment() {
+func ExampleNestedStructAccess() {
 	// Set an undefined nested pointer field - should get assigned like
 	// a regular non-pointer field
 	const code = `
@@ -2086,7 +2088,8 @@ func ExampleTransparentNestedStructPtrAssignment() {
 
 	a := TransparentPtrAccessA{}
 
-	L.SetGlobal("a", New(L, &a, ReflectOptions{TransparentPointers: true}))
+	L.SetGlobal("a", New(L, &a, ReflectOptions{
+		TransparentPointers: true, AutoPopulate: true}))
 
 	if err := L.DoString(code); err != nil {
 		panic(err)
@@ -2147,7 +2150,7 @@ type TransparentStructSliceFieldA struct {
 	List []string
 }
 
-func ExampleTransparentStructSliceField() {
+func ExampleAutoPopulateStructSliceField() {
 	// Access an undefined slice field - should be automatically created
 	const code = `
 	print(#a.List)
@@ -2158,7 +2161,8 @@ func ExampleTransparentStructSliceField() {
 
 	a := TransparentStructSliceFieldA{}
 
-	L.SetGlobal("a", New(L, &a, ReflectOptions{TransparentPointers: true}))
+	L.SetGlobal("a", New(L, &a, ReflectOptions{
+		TransparentPointers: true, AutoPopulate: true}))
 
 	if err := L.DoString(code); err != nil {
 		panic(err)
@@ -2168,7 +2172,7 @@ func ExampleTransparentStructSliceField() {
 	// 0
 }
 
-func ExampleTransparentStructSliceAppend() {
+func ExampleAutoPopulateStructSliceAppend() {
 	// Append to an undefined slice field - should be fine
 	const code = `
 	a.List = a.List:append("hi")
@@ -2180,7 +2184,8 @@ func ExampleTransparentStructSliceAppend() {
 
 	a := TransparentStructSliceFieldA{}
 
-	L.SetGlobal("a", New(L, &a, ReflectOptions{TransparentPointers: true}))
+	L.SetGlobal("a", New(L, &a, ReflectOptions{
+		TransparentPointers: true, AutoPopulate: true}))
 
 	if err := L.DoString(code); err != nil {
 		panic(err)
@@ -2291,7 +2296,7 @@ func TestImmutableTransparentPtrFieldAssignment(t *testing.T) {
 	}
 }
 
-func TestImmutableTransparentRead(t *testing.T) {
+func TestNonAutoPopulateRead(t *testing.T) {
 	// Attempt to read from nil on an immutable struct with transparent
 	// pointers.  This should still return nil, since we should not modify the
 	// immutable struct.
@@ -2310,7 +2315,7 @@ func TestImmutableTransparentRead(t *testing.T) {
 		Ptr  *int
 		List []int
 	}{}
-	L.SetGlobal("x", New(L, &x, ReflectOptions{Immutable: true, TransparentPointers: true}))
+	L.SetGlobal("x", New(L, &x, ReflectOptions{TransparentPointers: true}))
 
 	err := L.DoString(code)
 	if err != nil {

--- a/example_test.go
+++ b/example_test.go
@@ -2295,3 +2295,34 @@ func ExampleMultipleReflectedStructsDifferentOptions() {
 	// world
 	// hello
 }
+
+func ExampleTransparentPtrSliceCall() {
+	// Iterate over a slice via the call method. Access an undefined pointer
+	// field on the returned object. Returned object should inherit the transparent
+	// pointer behavior, and the field should be accessible without indirection.
+	const code = `
+	for i, b in slice() do
+		print(i)
+		print(b.Str)
+	end
+	`
+
+	L := lua.NewState()
+	defer L.Close()
+
+	val := "foo"
+	b := TransparentPtrAccessB{}
+	b.Str = &val
+
+	slice := []*TransparentPtrAccessB{&b}
+
+	L.SetGlobal("slice", New(L, slice, ReflectOptions{TransparentPointers: true}))
+
+	if err := L.DoString(code); err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// 1
+	// foo
+}

--- a/example_test.go
+++ b/example_test.go
@@ -1896,6 +1896,37 @@ func TestImmutableChanClose(t *testing.T) {
 	}
 }
 
+func TestImmutableFuncResult(t *testing.T) {
+	// When using reflect options on a function, those options should be applied
+	// to output values from the function. In this case, the output should have
+	// immutable behavior.
+
+	const code = `
+	person = getPerson()
+
+	-- person should have immutable behavior
+	person.Name = "Bob"
+	`
+
+	L := lua.NewState()
+	defer L.Close()
+
+	getPerson := func() *Person {
+		return &Person{Name: "Tim"}
+	}
+
+	L.SetGlobal("getPerson", New(L, getPerson, ReflectOptions{Immutable: true}))
+
+	err := L.DoString(code)
+	if err == nil {
+		t.Fatal("Expected error, none thrown")
+	}
+	if !strings.Contains(err.Error(), "invalid operation on immutable struct") {
+		t.Fatal("Expected invalid operation error, got:", err)
+	}
+}
+
+
 type TransparentPtrAccessB struct {
 	Str *string
 }
@@ -2325,4 +2356,34 @@ func ExampleTransparentPtrSliceCall() {
 	// Output:
 	// 1
 	// foo
+}
+
+func ExampleTransparentPtrFuncResult() {
+	// When using reflect options on a function, those options should be applied
+	// to output values from the function. In this case, the output should have
+	// transparent pointer behavior.
+
+	const code = `
+	b = newB()
+
+	-- b should have transparent ptr behavior
+	print(b.Str)
+	`
+
+	L := lua.NewState()
+	defer L.Close()
+
+	val := "hello"
+	newB := func() *TransparentPtrAccessB {
+		return &TransparentPtrAccessB{Str: &val}
+	}
+
+	L.SetGlobal("newB", New(L, newB, ReflectOptions{TransparentPointers: true}))
+
+	if err := L.DoString(code); err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// hello
 }

--- a/luar.go
+++ b/luar.go
@@ -74,7 +74,7 @@ func New(L *lua.LState, value interface{}, opts ...ReflectOptions) lua.LValue {
 		ud.Metatable = getMetatableFromValue(L, val)
 		return ud
 	case reflect.Func:
-		return funcWrapper(L, val, false)
+		return funcWrapper(L, val, false, reflectOptions)
 	case reflect.Interface:
 		ud := L.NewUserData()
 		ud.Value = newReflectedInterface(val.Interface(), reflectOptions)

--- a/luar.go
+++ b/luar.go
@@ -95,14 +95,17 @@ type ReflectOptions struct {
 	// Only works for a subset of types that utilize a custom metatable - arrays,
 	// channels, maps, pointers, slices and structs. Child elements/fields inherit
 	// the immutable property, even when assigned to new variables. Immutable
-	// channels may send/receive, but cannot be closed from Lua.
+	// channels may send/receive, but cannot be closed from Lua.  Note that if
+	// AutoPopulate is on,
 	Immutable bool
-	// For structs, will auto-populate and auto-indirect pointer fields. This
-	// makes structs with pointer fields behave like their non-pointer counterparts.
-	// Fields are populated with a zero-value object upon first access, and can
+	// For structs, will auto-indirect pointer fields. This makes structs with
+	// pointer fields behave like their non-pointer counterparts.  Fields can
 	// have values assigned directly without use of the pow (^) operator. Note
 	// that fields can only be set if the struct is reflected by reference.
 	TransparentPointers bool
+	// For structs, will auto-populate pointer fields with their appropriate Go
+	// type. This is only applicalble if TransparentPointers is on.
+	AutoPopulate bool
 }
 
 // Default options if no ReflectOptions struct is passed into luar.New().
@@ -110,6 +113,7 @@ func defaultReflectOptions() ReflectOptions {
 	return ReflectOptions{
 		Immutable:           false,
 		TransparentPointers: false,
+		AutoPopulate:        false,
 	}
 }
 

--- a/map.go
+++ b/map.go
@@ -85,7 +85,7 @@ func mapLen(L *lua.LState) int {
 }
 
 func mapCall(L *lua.LState) int {
-	ref, _, _, isPtr := check(L, 1, reflect.Map)
+	ref, opts, _, isPtr := check(L, 1, reflect.Map)
 	if isPtr {
 		L.RaiseError("invalid operation on map pointer")
 	}
@@ -95,8 +95,8 @@ func mapCall(L *lua.LState) int {
 		if i >= len(keys) {
 			return 0
 		}
-		L.Push(New(L, keys[i].Interface()))
-		L.Push(New(L, ref.MapIndex(keys[i]).Interface()))
+		L.Push(New(L, keys[i].Interface(), opts))
+		L.Push(New(L, ref.MapIndex(keys[i]).Interface(), opts))
 		i++
 		return 2
 	}

--- a/ptr.go
+++ b/ptr.go
@@ -63,12 +63,12 @@ func ptrPow(L *lua.LState) int {
 }
 
 func ptrUnm(L *lua.LState) int {
-	ref, _, _ := checkPtr(L, 1)
+	ref, opts, _ := checkPtr(L, 1)
 	elem := ref.Elem()
 	if !elem.CanInterface() {
 		L.RaiseError("cannot interface pointer type " + elem.String())
 	}
-	L.Push(New(L, elem.Interface()))
+	L.Push(New(L, elem.Interface(), opts))
 	return 1
 }
 

--- a/slice.go
+++ b/slice.go
@@ -72,7 +72,7 @@ func sliceLen(L *lua.LState) int {
 }
 
 func sliceCall(L *lua.LState) int {
-	ref, _, _, isPtr := check(L, 1, reflect.Slice)
+	ref, opts, _, isPtr := check(L, 1, reflect.Slice)
 	if isPtr {
 		L.RaiseError("invalid operation on slice pointer")
 	}
@@ -84,7 +84,7 @@ func sliceCall(L *lua.LState) int {
 		}
 		item := ref.Index(i).Interface()
 		L.Push(lua.LNumber(i + 1))
-		L.Push(New(L, item))
+		L.Push(New(L, item, opts))
 		i++
 		return 2
 	}
@@ -136,6 +136,6 @@ func sliceAppend(L *lua.LState) int {
 	}
 
 	newSlice := reflect.Append(ref, values...)
-	L.Push(New(L, newSlice.Interface()))
+	L.Push(New(L, newSlice.Interface(), opts))
 	return 1
 }

--- a/struct.go
+++ b/struct.go
@@ -44,7 +44,7 @@ func structIndex(L *lua.LState) int {
 				if !field.CanSet() {
 					L.RaiseError("cannot transparently create pointer field " + key)
 				}
-				if !opts.Immutable {
+				if opts.AutoPopulate {
 					field.Set(reflect.New(field.Type().Elem()))
 				}
 			}
@@ -61,7 +61,7 @@ func structIndex(L *lua.LState) int {
 				if !field.CanSet() {
 					L.RaiseError("cannot transparently create slice " + key)
 				}
-				if !opts.Immutable {
+				if opts.AutoPopulate {
 					field.Set(reflect.MakeSlice(field.Type(), 0, 10))
 				}
 			}

--- a/struct.go
+++ b/struct.go
@@ -44,7 +44,9 @@ func structIndex(L *lua.LState) int {
 				if !field.CanSet() {
 					L.RaiseError("cannot transparently create pointer field " + key)
 				}
-				field.Set(reflect.New(field.Type().Elem()))
+				if !opts.Immutable {
+					field.Set(reflect.New(field.Type().Elem()))
+				}
 			}
 
 			// Return the value of the pointer
@@ -59,7 +61,9 @@ func structIndex(L *lua.LState) int {
 				if !field.CanSet() {
 					L.RaiseError("cannot transparently create slice " + key)
 				}
-				field.Set(reflect.MakeSlice(field.Type(), 0, 10))
+				if !opts.Immutable {
+					field.Set(reflect.MakeSlice(field.Type(), 0, 10))
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Previously it was possible to modify immutable structs.  This seemed like unexpected behavior when reading off an immutable struct with a nil int pointer -- I did not expect to get back 0, and to have 0 written to the struct.