### PR TITLE
Error message when assigning an invalid variable to a struct field

### DIFF
--- a/struct.go
+++ b/struct.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 
 	"github.com/yuin/gopher-lua"
+	"fmt"
 )
 
 func structIndex(L *lua.LState) int {
@@ -104,6 +105,12 @@ func structNewIndex(L *lua.LState) int {
 		if field.Type().Kind() == reflect.Ptr {
 			hint := field.Type().Elem()
 			goValue := lValueToReflect(L, value, hint, nil)
+
+			if !goValue.IsValid() {
+				// Occurs if the assigned value does not match the expected
+				// type for the field
+				L.RaiseError(fmt.Sprintf("could not set field %s: expected type %v", key, hint))
+			}
 
 			if !field.CanSet() {
 				// Can happen if the field is on a struct reflected by

--- a/struct.go
+++ b/struct.go
@@ -1,10 +1,10 @@
 package luar
 
 import (
+	"fmt"
 	"reflect"
 
 	"github.com/yuin/gopher-lua"
-	"fmt"
 )
 
 func structIndex(L *lua.LState) int {

--- a/struct.go
+++ b/struct.go
@@ -1,7 +1,6 @@
 package luar
 
 import (
-	"fmt"
 	"reflect"
 
 	"github.com/yuin/gopher-lua"
@@ -109,7 +108,7 @@ func structNewIndex(L *lua.LState) int {
 			if !goValue.IsValid() {
 				// Occurs if the assigned value does not match the expected
 				// type for the field
-				L.RaiseError(fmt.Sprintf("could not set field %s: expected type %v", key, hint))
+				L.RaiseError("could not set field %s: could not convert value to %v", key, hint)
 			}
 
 			if !field.CanSet() {

--- a/struct_test.go
+++ b/struct_test.go
@@ -517,6 +517,21 @@ func Test_struct_transparentptr_assign(t *testing.T) {
 	testReturn(t, L, `return b.Str`, "assigned ptr value")
 }
 
+func Test_struct_transparentptr_assigninvalidtype(t *testing.T) {
+	// Assign an invalid type to a given field - should return
+	// a meaningful error
+	L := lua.NewState()
+	defer L.Close()
+
+	b1 := &TestTransparentPtrAccessB{}
+	b2 := &TestTransparentPtrAccessB{}
+
+	L.SetGlobal("b1", New(L, b1, ReflectOptions{TransparentPointers: true}))
+	L.SetGlobal("b2", New(L, b2, ReflectOptions{TransparentPointers: true}))
+
+	testError(t, L, `b1.Str = b2`, "could not set field Str: expected type string")
+}
+
 func Test_struct_transparentptr_nonptrvar(t *testing.T) {
 	// Attempt to access a nil pointer field on a transparent pointer
 	// struct that was reflected by value. Since we can't actually set

--- a/struct_test.go
+++ b/struct_test.go
@@ -529,7 +529,7 @@ func Test_struct_transparentptr_assigninvalidtype(t *testing.T) {
 	L.SetGlobal("b1", New(L, b1, ReflectOptions{TransparentPointers: true}))
 	L.SetGlobal("b2", New(L, b2, ReflectOptions{TransparentPointers: true}))
 
-	testError(t, L, `b1.Str = b2`, "could not set field Str: expected type string")
+	testError(t, L, `b1.Str = b2`, "could not set field Str: could not convert value to string")
 }
 
 func Test_struct_transparentptr_nonptrvar(t *testing.T) {


### PR DESCRIPTION
The previous implementation resulted in a panic like:

```reflect: call of reflect.Value.Type on zero Value```

The message now looks like:

```script.lua:1: could not set field Str: expected type string```

This error previously resulted in a useful panic message within `lValueToReflect`, but that function recently changed to not panic, and just return an invalid `reflect.Value`.