### PR TITLE
Raise more meaningful error for mistyped function inputs

### DIFF
--- a/func.go
+++ b/func.go
@@ -113,6 +113,9 @@ func funcRegular(L *lua.LState) int {
 			receiver = arg
 		} else {
 			arg = lValueToReflect(L, L.Get(i+1), hint, nil)
+			if !arg.IsValid() {
+				L.RaiseError("invalid type received for arg %d (expected %s)", i+1, hint)
+			}
 		}
 		args[i] = arg
 	}

--- a/func_test.go
+++ b/func_test.go
@@ -218,6 +218,22 @@ func Test_func_luafunccall(t *testing.T) {
 	}
 }
 
+func Test_func_invalidargtype(t *testing.T) {
+	L := lua.NewState()
+	defer L.Close()
+
+	family := &StructTestFamily{}
+
+	fn := func(p *StructTestPerson) string {
+		return "Hello, " + p.Name
+	}
+
+	L.SetGlobal("family", New(L, family))
+	L.SetGlobal("getHello", New(L, fn))
+
+	testError(t, L, `return getHello(family)`, "invalid type received for arg 1 (expected *luar.StructTestPerson)")
+}
+
 func Test_func_immutable_result(t *testing.T) {
 	// When using reflect options on a function, those options should be applied
 	// to output values from the function. In this case, the output should have


### PR DESCRIPTION
Previous error was `reflect: Call using zero Value argument`.